### PR TITLE
In scalatra-test, get("url") will actually connect to "url?" (a question mark appended)

### DIFF
--- a/test/src/main/scala/org/scalatra/test/ScalatraTests.scala
+++ b/test/src/main/scala/org/scalatra/test/ScalatraTests.scala
@@ -38,7 +38,9 @@ trait ScalatraTests {
       r.setMethod(method)
       r.setURI(uri)
       method.toLowerCase match {
-	case "get" => r.setURI(uri + "?" + paramStr)
+	case "get" => {
+	    r.setURI(uri + (if (paramStr == "") "" else "?") + paramStr)
+  }
 	case "post" => r.setContent(paramStr)
 	// @todo case "put"
 	// @todo case "delete"


### PR DESCRIPTION
I made a little condition to see if the paramStr is empty, then don't add question mark.
So we can directly get("url?k1=v1&k2=v2") without getting k2="v2?".
