### PR TITLE
minor README fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -447,7 +447,7 @@ Scalatra was renamed from Step to Scalatra to avoid a naming conflict with (an u
 
 ### Other contributors
 
-- [The Sinatra Project](http://sinatrarb.com/), whose excellent framework, test suite, and documentation we've shamelessly copied.
+- [The Sinatra Project](http://www.sinatrarb.com/), whose excellent framework, test suite, and documentation we've shamelessly copied.
 - [Mark Harrah](http://github.com/harrah) for his support on the SBT mailing list.
 - [Yusuke Kuoka](http://github.com/mumoshu) for adding sessions and header support
 - [Miso Korkiakoski](http://github.com/mwing) for various patches.


### PR DESCRIPTION
the Sinatra Project url http://sinatrarb.com/ in the README brings up a GoDaddy page. This tiny fix (change to http://www.sinatrarb.com/)  brings up the actual home page --

best,
Ted
