### PR TITLE
Decode request body with content encoding

### DIFF
--- a/core/src/main/scala/org/scalatra/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/RichRequest.scala
@@ -19,7 +19,7 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
   }
 
   def body:String = {
-    Source.fromInputStream(r.getInputStream).mkString
+    Source.fromInputStream(r.getInputStream, r.getCharacterEncoding).mkString
   }
 
   def isAjax: Boolean = r.getHeader("X-Requested-With") != null

--- a/core/src/test/scala/org/scalatra/RichRequestTest.scala
+++ b/core/src/test/scala/org/scalatra/RichRequestTest.scala
@@ -1,0 +1,37 @@
+package org.scalatra
+
+import java.io.ByteArrayInputStream
+import javax.servlet.ServletInputStream
+import javax.servlet.http.HttpServletRequest
+import org.junit.runner.RunWith
+import org.mockito.Mockito._
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.matchers.ShouldMatchers
+
+@RunWith(classOf[JUnitRunner])
+class RichRequestTest extends FunSuite with ShouldMatchers {
+  implicit def requestWrapper(r: HttpServletRequest) = RichRequest(r)
+
+  test("decodes body according to the character encoding") {
+    val encoding = "ISO-8859-5"
+    val message = "cyrillic content: Ж, Щ, л"
+    val content = message.getBytes(encoding)
+
+    val request = createStubRequest(content, encoding)
+
+    request.body should equal (message)
+  }
+
+  def createStubRequest(content: Array[Byte], encoding: String): HttpServletRequest = {
+    val request = mock(classOf[HttpServletRequest])
+    when(request.getInputStream).thenReturn(new FakeServletInputStream(content))
+    when(request.getCharacterEncoding).thenReturn(encoding)
+    request
+  }
+}
+
+private[scalatra] class FakeServletInputStream(data: Array[Byte]) extends ServletInputStream {
+  private val backend = new ByteArrayInputStream(data)
+  def read = backend.read
+}


### PR DESCRIPTION
There seems to be bug in RichRequest#body: the contents of the request are not decoded with the character encoding of the request (but instead with JVM's default encoding). This patch fixes and adds a test for it.

Best regards,
  Tuomas Kareinen
