### PR TITLE
Expose the CSRFTokenSupport trait's forgery test expression as a method

### DIFF
--- a/core/src/main/scala/org/scalatra/CSRFTokenSupport.scala
+++ b/core/src/main/scala/org/scalatra/CSRFTokenSupport.scala
@@ -26,9 +26,18 @@ trait CSRFTokenSupport { self: ScalatraKernel =>
   protected def csrfToken = session(csrfKey).asInstanceOf[String]
 
   before {
-    if (request.isWrite && session.get(csrfKey) != params.get(csrfKey))
+    if (isForged)
       halt(403, "Request tampering detected!")
     prepareCSRFToken
+  }
+
+  /**
+   * Test whether a POST request is a potential cross-site forgery.
+   *
+   * @return Returns true if the POST request is suspect.
+   */
+  protected def isForged: Boolean = {
+    request.isWrite && session.get(csrfKey) != params.get(csrfKey)
   }
 
   protected def prepareCSRFToken = {


### PR DESCRIPTION
Allow CSRFTokenSupport-derived traits to redefine the forgery test.

This commit does not include any additional tests  as the semantics should not change. The forgery test was exposed to derived types.
