### PR TITLE
Fixed the Scalate layout call in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -323,7 +323,7 @@ Scalatra provides optional support for [Scalate](http://scalate.fusesource.org/)
 3. A template engine is created as the `templateEngine` variable.  This can be used to render templates and call layouts.
 
        get("/") {
-         templateEngine.layout("index.scaml", "content" -> "yada yada yada")
+         templateEngine.layout("index.scaml", Map("content" -> "yada yada yada"))
        }
 
 Additionally, `createRenderContext` may be used to create a render context for the current request and response. 


### PR DESCRIPTION
The correct argument for parameters to a layout call in Scalate is Map, the docs had a Tuple. Didn't take too long to track down, but hopefully this saves someone else the trouble. 
