### PR TITLE
Trait for Lift JSON rendering

### DIFF
--- a/lift-json/src/main/scala/org/scalatra/lift/JsonSupport.scala
+++ b/lift-json/src/main/scala/org/scalatra/lift/JsonSupport.scala
@@ -1,0 +1,21 @@
+package org.scalatra.lift
+
+import org.scalatra.ScalatraKernel
+import net.liftweb.json.JsonAST.JValue
+
+/**
+ * Trait which renders Lift JValues as JSON.
+ */
+trait JsonSupport extends ScalatraKernel {
+
+  override protected def contentTypeInfer = {
+    case _ : JValue => "application/json; charset=utf-8"
+  }
+
+  override protected def renderPipeline = {
+    case jv : JValue =>
+      import net.liftweb._
+      val bytes = json.compact(json.render(jv)).getBytes("UTF-8")
+      response.getOutputStream.write(bytes)
+  }
+}

--- a/lift-json/src/test/scala/org/scalatra/lift/JsonSupportTest.scala
+++ b/lift-json/src/test/scala/org/scalatra/lift/JsonSupportTest.scala
@@ -1,0 +1,26 @@
+package org.scalatra.lift
+
+import org.scalatra.test.scalatest.ScalatraFunSuite
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatra.ScalatraServlet
+
+class JsonSupportTest extends ScalatraFunSuite with ShouldMatchers {
+  val servletHolder = addServlet(classOf[JsonSupportTestServlet], "/*")
+  servletHolder.setInitOrder(1) // force load on startup
+
+  test("JSON support test") {
+    get("/json") {
+      response.mediaType should equal (Some("application/json"))
+      response.body should equal ("""{"k1":"v1","k2":"v2"}""")
+    }
+  }
+}
+
+
+class JsonSupportTestServlet extends ScalatraServlet with JsonSupport {
+  get("/json") {
+    import net.liftweb.json.JsonDSL._
+    ("k1" -> "v1") ~
+      ("k2" -> "v2")
+  }
+}

--- a/project/build/ScalatraProject.scala
+++ b/project/build/ScalatraProject.scala
@@ -142,6 +142,12 @@ class ScalatraProject(info: ProjectInfo)
     val description = "Supplies optional SocketIO support for scalatra"
   }
 
+  lazy val liftJson = project("lift-json", "scalatra-lift-json", new LiftJsonProject(_), core)
+  class LiftJsonProject(info: ProjectInfo) extends DefaultProject(info) with ScalatraSubproject with TestWithScalatraTest {
+    val liftJson = "net.liftweb" %% "lift-json" % "2.4-M2" % "compile"
+    val description = "Supplies optional Lift JSON support for scalatra"
+  }
+
   lazy val example = project("example", "scalatra-example", new ExampleProject(_), core, fileupload, scalate, auth, socketio)
   class ExampleProject(info: ProjectInfo) extends DefaultWebProject(info) with ScalatraSubproject with UnpublishedProject {
     val jetty7 = jettyGroupId % "jetty-webapp" % jettyVersion % "test"


### PR DESCRIPTION
New submodule with a JsonSupport trait which automatically renders Lift JSON JValues as JSON. Trivial to implement, but still useful.
