### PR TITLE
Should the maven id of the thing be listed somewhere?

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,8 @@ Scalatra is a tiny, [Sinatra](http://www.sinatrarb.com/)-like web framework for 
       }
     }
 
-### As a library for your existing project:
+
+## As a library for your existing project:
    Scalatra is available from Maven Central by listing the following library dependency in your SBT (or something similiar for Maven/Gradle/etc) configuration:
 
     "org.scalatra" %% "scalatra" % "2.0.0.M4"


### PR DESCRIPTION
For people just looking to download the lib to their existing project and go.  Someone mentioned this before - maybe they were scared by all the talk of conscript and giter8 right off the bat?  Wouldn't want to give people the impression there are extra requirements to use this thing.
