### PR TITLE
Improve default servlet notFound with an HTML list of entry points

### DIFF
--- a/core/src/main/scala/org/scalatra/RouteRegistry.scala
+++ b/core/src/main/scala/org/scalatra/RouteRegistry.scala
@@ -100,12 +100,11 @@ class RouteRegistry {
   /**
    * List of entry points, made of all route matchers
    */
-  def entryPoints: Iterable[String] =
-    for {
+  def entryPoints: Seq[String] =
+    (for {
       (method, routes) <- methodRoutes
       route <- routes
-    } yield method + " " + route
+    } yield method + " " + route).toSeq sortWith (_ < _)
 
-  override def toString(): String =
-    entryPoints.toSeq sortWith (_ < _) mkString ", "
+  override def toString(): String = entryPoints mkString ", "
 }

--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -26,7 +26,11 @@ abstract class ScalatraServlet
 
   protected var doNotFound: Action = () => {
     response.setStatus(404)
-    response.getWriter println "Requesting %s but only have %s".format(request.getRequestURI, routes)
+    if (isDevelopmentMode)
+      response.getWriter println "Requesting %s %s but only have: %s".format(
+        request.getMethod,
+        request.getRequestURI,
+        routes.entryPoints.mkString("<ul><li>", "</li><li>", "</li></ul>"))
   }
 
   def servletContext: ServletContext = getServletContext


### PR DESCRIPTION
New notFound output example:

```
Requesting GET /test but only have:
    - GET /foo
    - GET /routes
    - GET /
```
