### PR TITLE
Add syntax sugars for renderTemplate like scaml,ssp,jade,mustache.

### DIFF
--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateHelper.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateHelper.scala
@@ -1,0 +1,45 @@
+package org.scalatra
+package scalate
+
+/**
+ * A ScalateHelper provides following syntax sugars for renderTemplate.
+ * `jade`, `scaml`, `ssp`, `mustache`
+ */
+trait ScalateHelper {
+  this: ScalateSupport =>
+
+  lazy val defaultIndexName    = "index"
+  lazy val defaultFormat       = "scaml"
+  lazy val defaultTemplatePath = "/WEB-INF/scalate/templates"
+
+  /**
+   * Syntax sugars for various scalate formats
+   */
+  def jade     = renderTemplateAs("jade") _
+  def scaml    = renderTemplateAs("scaml") _
+  def ssp      = renderTemplateAs("ssp") _
+  def mustache = renderTemplateAs("mustache") _
+
+  protected def renderTemplateAs(ext: String)(path: String, attributes: (String, Any)*) =
+    templateEngine.layout(findTemplate(path, ext), Map(attributes : _*))
+
+  /**
+   * Return a template path with WEB-INF prefix.
+   */
+  protected def findTemplate(name: String, ext: String = defaultFormat) =
+    defaultTemplatePath + "/" + completeTemplateName(name, ext)
+
+  /**
+   * Complate template name about default index and extname
+   */
+  protected def completeTemplateName(name: String, ext: String) = {
+    val base = name match {
+      case s if s.endsWith("/") => s + defaultIndexName
+      case s => s
+    }
+    base match {
+      case s if s.contains(".") => s
+      case s => s + "." + ext
+    }
+  }
+}

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
@@ -23,7 +23,7 @@ object ScalateSupport {
   }
 }
 
-trait ScalateSupport extends ScalatraKernel {
+trait ScalateSupport extends ScalatraKernel with ScalateHelper {
   protected var templateEngine: TemplateEngine = _
 
   abstract override def initialize(config: Config) {

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/params.jade
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/params.jade
@@ -1,0 +1,3 @@
+-@var foo: String
+
+div #{foo} template

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/params.mustache
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/params.mustache
@@ -1,0 +1,1 @@
+<div>{{foo}} template</div>

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/params.scaml
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/params.scaml
@@ -1,0 +1,2 @@
+-@var foo: String
+%div= "%s template".format(foo)

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/params.ssp
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/params.ssp
@@ -1,0 +1,2 @@
+<%@ var foo: String %>
+<div><%= foo %> template</div>

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/simple.jade
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/simple.jade
@@ -1,0 +1,1 @@
+div Jade template

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/simple.mustache
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/simple.mustache
@@ -1,0 +1,1 @@
+<div>Mustache template</div>

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/simple.scaml
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/simple.scaml
@@ -1,0 +1,1 @@
+%div Scaml template

--- a/scalate/src/test/resources/WEB-INF/scalate/templates/simple.ssp
+++ b/scalate/src/test/resources/WEB-INF/scalate/templates/simple.ssp
@@ -1,0 +1,1 @@
+<div><%= "SSP template" %></div>

--- a/scalate/src/test/scala/org/scalatra/scalate/ScalateSupportSpec.scala
+++ b/scalate/src/test/scala/org/scalatra/scalate/ScalateSupportSpec.scala
@@ -13,7 +13,15 @@ class ScalateSupportSpec extends ScalatraSpec { def is =
     "render a simple template with params"                        ! e4^
     "looks for layouts in /WEB-INF/layouts"                       ! e5^
     "generate a url from a template"                              ! e6^
-    "generate a url with params from a template"                  ! e7
+    "generate a url with params from a template"                  ! e7^
+    "render a simple template via jade method"                    ! e8^
+    "render a simple template with params via jade method"        ! e9^
+    "render a simple template via scaml method"                   ! e10^
+    "render a simple template with params via scaml method"       ! e11^
+    "render a simple template via ssp method"                     ! e12^
+    "render a simple template with params via ssp method"         ! e13^
+    "render a simple template via mustache method"                ! e14^
+    "render a simple template with params via mustache method"    ! e15
 
   addServlet(new ScalatraServlet with ScalateSupport with ScalateUrlGeneratorSupport {
 
@@ -31,6 +39,38 @@ class ScalateSupportSpec extends ScalatraSpec { def is =
 
     get("/params") {
       renderTemplate("/params.jade", "foo" -> "Configurable")
+    }
+
+    get("/jade-template") {
+      jade("simple")
+    }
+
+    get("/jade-params") {
+      jade("params", "foo" -> "Configurable")
+    }
+
+    get("/scaml-template") {
+      scaml("simple")
+    }
+
+    get("/scaml-params") {
+      scaml("params", "foo" -> "Configurable")
+    }
+
+    get("/ssp-template") {
+      ssp("simple")
+    }
+
+    get("/ssp-params") {
+      ssp("params", "foo" -> "Configurable")
+    }
+
+    get("/mustache-template") {
+      mustache("simple")
+    }
+
+    get("/mustache-params") {
+      mustache("params", "foo" -> "Configurable")
     }
 
     get("/layout-strategy") {
@@ -84,5 +124,37 @@ class ScalateSupportSpec extends ScalatraSpec { def is =
 
   def e7 = get("/url-generation-with-params/jedi/vs/sith") {
     body must_== "/url-generation-with-params/jedi/vs/sith\n"
+  }
+
+  def e8 = get("/jade-template") {
+    body must_== "<div>Jade template</div>\n"
+  }
+
+  def e9 = get("/jade-params") {
+    body must_== "<div>Configurable template</div>\n"
+  }
+
+  def e10 = get("/scaml-template") {
+    body must_== "<div>Scaml template</div>\n"
+  }
+
+  def e11 = get("/scaml-params") {
+    body must_== "<div>Configurable template</div>\n"
+  }
+
+  def e12 = get("/ssp-template") {
+    body must_== "<div>SSP template</div>\n"
+  }
+
+  def e13 = get("/ssp-params") {
+    body must_== "<div>Configurable template</div>\n"
+  }
+
+  def e14 = get("/mustache-template") {
+    body must_== "<div>Mustache template</div>\n"
+  }
+
+  def e15 = get("/mustache-params") {
+    body must_== "<div>Configurable template</div>\n"
   }
 }


### PR DESCRIPTION
There are two merits.
- simple: just type "scaml" to render with scaml format
- path free: no needs to care "WEB-INF/..."

before

``` scala
renderTemplate("/WEB-INF/scalate/templates/foo.scaml")
```

after

``` scala
scaml("foo")
```
