### PR TITLE
allow LiftJsonRequestBody.jsonFormats to be overridden

### DIFF
--- a/lift-json/src/main/scala/org/scalatra/liftjson/LiftJsonRequestBody.scala
+++ b/lift-json/src/main/scala/org/scalatra/liftjson/LiftJsonRequestBody.scala
@@ -18,7 +18,7 @@ object LiftJsonRequestBody {
  */
 trait LiftJsonRequestBody extends ScalatraKernel with ApiFormats {
 
-  protected implicit def jsonFormats = DefaultFormats
+  protected implicit def jsonFormats: Formats = DefaultFormats
 
   import LiftJsonRequestBody._
  


### PR DESCRIPTION
I need to override `jsonFormats` from `LiftJsonRequestBody` with my own type hints.  I tried the following:

```
override implicit def jsonFormats = new DefaultFormats { .... }
```

But got the following compilation error:

```
[error]  found   : java.lang.Object with net.liftweb.json.DefaultFormats{}
[error]  required: net.liftweb.json.DefaultFormats.type
```

I believe this is because `jsonFormats` is inferred to have the type of `object DefaultFormats` rather than `class DefaultFormats` or, more generally, `Formats`.  This patch makes the type explicit.
