### PR TITLE
Add JSONP support to the JsonSupport trait.

### DIFF
--- a/lift-json/src/main/scala/org/scalatra/liftjson/JsonSupport.scala
+++ b/lift-json/src/main/scala/org/scalatra/liftjson/JsonSupport.scala
@@ -9,6 +9,15 @@ import net.liftweb.json.JsonAST.JValue
  */
 trait JsonSupport extends ScalatraKernel {
 
+  /**
+   * If a request is made with a parameter in jsonpCallbackParameterNames it will
+   * be assumed that it is a JSONP request and the json will be returned as the
+   * argument to a function with the name specified in the corresponding parameter.
+   *
+   * By default no parameterNames will be checked
+   */
+  def jsonpCallbackParameterNames:  Iterable[String] = None
+
   override protected def contentTypeInferrer = ({
     case _ : JValue => "application/json; charset=utf-8"
   }: ContentTypeInferrer) orElse super.contentTypeInferrer
@@ -16,8 +25,13 @@ trait JsonSupport extends ScalatraKernel {
   override protected def renderPipeline = ({
     case jv : JValue =>
       import net.liftweb._
-      json.compact(json.render(jv)).getBytes("UTF-8")
+      val jsonString = json.compact(json.render(jv))
+
+      val jsonWithCallback = for {
+        paramName <- jsonpCallbackParameterNames
+        callback <- params.get(paramName)
+      } yield "%s(%s);" format (callback, jsonString)
+
+      (jsonWithCallback.headOption.getOrElse(jsonString)).getBytes("UTF-8")
   }: RenderPipeline) orElse super.renderPipeline
-
-
 }

--- a/lift-json/src/test/scala/org/scalatra/liftjson/JsonSupportTest.scala
+++ b/lift-json/src/test/scala/org/scalatra/liftjson/JsonSupportTest.scala
@@ -4,13 +4,27 @@ import org.scalatra.test.scalatest.ScalatraFunSuite
 import org.scalatra.ScalatraServlet
 
 class JsonSupportTest extends ScalatraFunSuite {
-  val servletHolder = addServlet(classOf[JsonSupportTestServlet], "/*")
-  servletHolder.setInitOrder(1) // force load on startup
+  addServlet(classOf[JsonSupportTestServlet], "/*")
+  addServlet(classOf[JsonPTestServlet], "/p/*")
 
   test("JSON support test") {
     get("/json") {
       response.mediaType should equal (Some("application/json"))
       response.body should equal ("""{"k1":"v1","k2":"v2"}""")
+    }
+  }
+
+  test("JSONP callback test with no callback name specified") {
+    get("/json", "callback" -> "function") {
+      response.mediaType should equal (Some("application/json"))
+      response.body should equal ("""{"k1":"v1","k2":"v2"}""")
+    }
+  }
+
+  test("JSONP callback test with callback name specified") {
+    get("/p/jsonp", "callback" -> "function") {
+      response.mediaType should equal (Some("application/json"))
+      response.body should equal ("""function({"k1":"v1","k2":"v2"});""")
     }
   }
 }
@@ -21,5 +35,15 @@ class JsonSupportTestServlet extends ScalatraServlet with JsonSupport {
     import net.liftweb.json.JsonDSL._
     ("k1" -> "v1") ~
       ("k2" -> "v2")
+  }
+}
+
+class JsonPTestServlet extends ScalatraServlet with JsonSupport {
+  override def jsonpCallbackParameterNames = Some("callback")
+
+  get("/jsonp") {
+    import net.liftweb.json.JsonDSL._
+    ("k1" -> "v1") ~
+    ("k2" -> "v2")
   }
 }


### PR DESCRIPTION
We wanted JSONP support for an API we were using Scalatra for and I couldn't see a decent way of doing it without reimplementing or modifying JsonSupport.  

I think this should be completely backwards compatible and I've added a test to that effect.

jsonpCallbackParameterNames seems almost Springesque in its verbosity, so if anyone can think of something more concise that conveys the meaning, that would be welcome.
