### PR TITLE
Scala comment nesting fix.

### DIFF
--- a/example/src/main/scala/Scalatra.scala
+++ b/example/src/main/scala/Scalatra.scala
@@ -13,7 +13,7 @@ class Scalatra extends LifeCycle {
     val meteor = new ServletHolder(classOf[org.atmosphere.cpr.MeteorServlet])
     meteor.setInitParameter("org.atmosphere.servlet", "org.scalatra.MeteorChatExample")
     meteor.setInitOrder(0)
-    context.mount(meteor, "/meteor/*") 
+    context.mount(meteor, "/meteor/*") */
     */
     
     context.mount(new CookiesExample, "/cookies-example/*")


### PR DESCRIPTION
This should fix the build, Scala's nested comments made the route matcher /meteor/\* inside the comment block
break compilation.
