### PR TITLE
Fixing a couple URLs in comments

### DIFF
--- a/.history
+++ b/.history
@@ -1,3 +1,0 @@
-exit
-compile
-exit


### PR DESCRIPTION
Was looking at FlashMapSupport to write some more docs there, noticed that the github URLs are pointed at github.org instead of github.com - quick fix here. 
