### PR TITLE
Fixed #158 - [2.0.x] CookieSupport ignores HttpOnly

### DIFF
--- a/core/src/main/scala/org/scalatra/CookieSupport.scala
+++ b/core/src/main/scala/org/scalatra/CookieSupport.scala
@@ -58,16 +58,11 @@ class SweetCookies(private val reqCookies: Map[String, String], private val resp
   def apply(key: String) = cookies.get(key) getOrElse (throw new Exception("No cookie could be found for the specified key"))
 
   def update(name: String, value: String)(implicit cookieOptions: CookieOptions=CookieOptions()) = {
-    val sCookie = new ServletCookie(name, value)
-    if(cookieOptions.domain.isNonBlank) sCookie.setDomain(cookieOptions.domain)
-    if(cookieOptions.path.isNonBlank) sCookie.setPath(cookieOptions.path)
-    sCookie.setMaxAge(cookieOptions.maxAge)
-    if(cookieOptions.secure) sCookie.setSecure(cookieOptions.secure)
-    if(cookieOptions.comment.isNonBlank) sCookie.setComment(cookieOptions.comment)
+    val cookie = new Cookie(name, value)
+    // use HttpServletResponse#addHeader because Servlet API 2.5 does'nt support the HttpOnly flag
+    response.addHeader("Set-Cookie", cookie.toCookieString)
     cookies += name -> value
-    //response.addHeader("Set-Cookie", cookie.toCookieString)
-    response.addCookie(sCookie)
-    sCookie
+    cookie.toServletCookie
   }
 
   def set(name: String, value: String)(implicit cookieOptions: CookieOptions=CookieOptions()) = {

--- a/core/src/test/scala/org/scalatra/CookieSupportTest.scala
+++ b/core/src/test/scala/org/scalatra/CookieSupportTest.scala
@@ -26,6 +26,10 @@ class CookieSupportServlet extends ScalatraServlet with CookieSupport {
     cookies.update("thecookie", params("cookieval"))(CookieOptions(maxAge = params("maxAge").toInt))
   }
 
+  post("/set-http-only-cookie") {
+    cookies.update("thecookie", params("cookieval"))(CookieOptions(httpOnly = true))
+  }
+
   post("/maplikeset") {
     cookies += ("somecookie" -> params("cookieval"))
     "OK"
@@ -46,7 +50,7 @@ class CookieSupportTest extends ScalatraFunSuite {
 
   test("POST /setcookie with a value should return OK") {
     post("/foo/setcookie", "cookieval" -> "The value") {
-      response.getHeader("Set-Cookie") must startWith ("""somecookie="The value";""")
+      response.getHeader("Set-Cookie") must startWith ("""somecookie=The value;""")
     }
   }
 
@@ -69,9 +73,15 @@ class CookieSupportTest extends ScalatraFunSuite {
     }
   }
 
+  test("POST /set-http-only-cookie should set the HttpOnly flag of the cookie") {
+    post("/foo/set-http-only-cookie", "cookieval" -> "whatever") {
+      response.getHeader("Set-Cookie") must endWith ("; HttpOnly")
+    }
+  }
+
   test("cookie path defaults to context path") {
     post("/foo/setcookie", "cookieval" -> "whatever") {
-      response.getHeader("Set-Cookie") must endWith (";Path=/foo")
+      response.getHeader("Set-Cookie") must endWith ("; Path=/foo")
     }
   }
 
@@ -79,7 +89,7 @@ class CookieSupportTest extends ScalatraFunSuite {
     post("/foo/maplikeset", "cookieval" -> "whatever") {
       val hdr = response.getHeader("Set-Cookie")
       hdr must startWith ("""somecookie=whatever;""")
-      hdr must endWith (";Path=/foo")
+      hdr must endWith ("; Path=/foo")
     }
   }
 


### PR DESCRIPTION
For this issue: https://github.com/scalatra/scalatra/issues/158

It needed to change some tests because of the difference of `org.scalatra.Cookie#toCookieString` and Servlet API's set-cookie value.
