### PR TITLE
Remove debug log messages from ScalatraTests

### DIFF
--- a/test/src/main/scala/org/scalatra/test/ScalatraTests.scala
+++ b/test/src/main/scala/org/scalatra/test/ScalatraTests.scala
@@ -52,9 +52,7 @@ trait ScalatraTests extends JettyContainer with Client {
 
       case _ => {
         val reqString = req.generate
-        log.debug("request\n"+reqString)
         val resString = tester.getResponses(req.generate)
-        log.debug("response\n"+resString)
         res.parse(resString, req.getMethod == "HEAD")
       }
     }


### PR DESCRIPTION
Removed debug log messages from ScalatraTests. These debug messages
do not add much value to the user and, if the user has debug level
enabled, will result in quite messy test output. In some cases,
such as when handling binary data, these messages even cause
iTerm 2 to crash.
