### PR TITLE
Chopping off ;

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraFilter.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraFilter.scala
@@ -40,7 +40,12 @@ trait ScalatraFilter extends Filter with ServletBase {
     case requestURI: String =>
       var uri = requestURI
       if (request.getContextPath.length > 0) uri = uri.substring(request.getContextPath.length)
-      if (uri.length == 0) uri = "/"
+      if (uri.length == 0) {
+        uri = "/"
+      } else {
+        val pos = uri.indexOf(';')
+        if (pos >= 0) uri = uri.substring(0, pos)
+      }
       UriDecoder.firstStep(uri)
     case null => "/"
   }

--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -40,7 +40,12 @@ abstract class ScalatraServlet
       var uri = requestURI
       if (request.getContextPath.length > 0) uri = uri.substring(request.getContextPath.length)
       if (request.getServletPath.length > 0) uri = uri.substring(request.getServletPath.length)
-      if (uri.length == 0) uri = "/"
+      if (uri.length == 0) {
+        uri = "/"
+      } else {
+        val pos = uri.indexOf(';')
+        if (pos >= 0) uri = uri.substring(0, pos)
+      }
       UriDecoder.firstStep(uri)
     case null => "/"
   }

--- a/core/src/test/scala/org/scalatra/RouteTest.scala
+++ b/core/src/test/scala/org/scalatra/RouteTest.scala
@@ -109,6 +109,14 @@ class RouteTestServlet extends ScalatraServlet {
   get("/encoded-uri-3/%C3%B6") {
     "ö"
   }
+  
+  get("/semicolon/?") {
+    "semicolon"
+  }
+
+  get("/semicolon/document") {
+    "document"
+  }
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -209,6 +217,12 @@ class RouteTest extends ScalatraFunSuite {
   test("literally matches () in paths") {
     get("/test(bar)") {
       body should equal ("test(bar)")
+    }
+  }
+  
+  test("literally matches ; in paths") {
+    get("/foo;123") {
+      status should equal (200)
     }
   }
 
@@ -313,4 +327,22 @@ class RouteTest extends ScalatraFunSuite {
       status should equal (200)
     }
   }
+  
+   test("should chop off uri starting from semicolon") {
+    get("/semicolon;jessionid=9328475932475") {
+      status should equal(200)
+      body should equal("semicolon")
+    }
+
+    get("/semicolon/;jessionid=9328475932475") {
+      status should equal(200)
+      body should equal("semicolon")
+    }
+
+    get("/semicolon/document;version=3/section/2") {
+      status should equal(200)
+      body should equal("document")
+    }
+  }
+
 }


### PR DESCRIPTION
This patch removes ;.\* from the URI. This is needed due to servlet appending ;jessionid=.. .
