### PR TITLE
Use regular POST/PUT when using post/put overloaded with empty files and...

### DIFF
--- a/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
+++ b/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
@@ -27,6 +27,18 @@ class FileUploadTestHelpersTestServlet extends ScalatraServlet with FileUploadSu
     "OK"
   }
 
+  post("/no-files") {
+    handleRequest()
+
+    "/no-files"
+  }
+
+  post("/no-files-or-params") {
+    handleRequest()
+
+    "/no-files-or-params"
+  }
+
   put("/") {
     handleRequest()
 
@@ -94,6 +106,20 @@ class FileUploadTestHelpersTest extends ScalatraFunSuite {
       assert(header("File-binaryFile-Name") === "smiley.png")
       assert(header("File-binaryFile-Size") === "3432")
       assert(header("File-binaryFile-SHA") === "0e777b71581c631d056ee810b4550c5dcd9eb856")
+    }
+  }
+
+  test("post with empty files map works") {
+    post("/", params, Map[String, File](), Map[String, String]()) {
+      assert(header("Param-one") === "1")
+      assert(header("Param-two") === "2")
+    }
+  }
+
+  test("post with empty files and params map works") {
+    post("/no-files-or-params", Map[String, String](), Map[String, File](), Map[String, String]()) {
+      assert(status === 200)
+      assert(body   === "/no-files-or-params")
     }
   }
 }


### PR DESCRIPTION
... params

Fix a small issue using post/put overloaded with the files map
in ScalatraTests. Whenever the user would use the overloaded
method and provide empty files map AND params map, it would
generate a multipart/form-data request with empty body.

This causes a problem with Jetty, which throws IOException with message
"Missing initial multi part boundary" whenever it tries to parse a
multipart request with zero parts, and thus indeed, a one not having
the initial boundary.

The changes in this commit fix the issue by handling the special
case of params.isEmpty && files.isEmpty by falling back to regular
submit unless the user explicitly specified "multipart/form-data"
for Content-Type header.

Having this change enables users to do something like this
without needing any special handling from their part:

```
def changeAvatar[A](userId: Int = 123, file: File = defaultFile)(f: => A): A = {
  put("/users/" + userId + "/avatar",
    Map[String, String](),
    (file != null) Map("file" -> file) else Map[String, File]()) { f }
}

test("user can change avatar") {
  changeAvatar {
    assert(user avatar has changed)
  }
}

test("changing avatar without providing file fails") {
  changeAvatar(file = null) {
    assert(avatar was not changed)
    assert(status === 400)
  }
}
```
