### PR TITLE
Infer content type from the headers map given with ActionResult

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -246,7 +246,11 @@ trait ScalatraBase extends CoreDsl with DynamicScope with Initializable
   protected def contentTypeInferrer: ContentTypeInferrer = {
     case _: String => "text/plain"
     case _: Array[Byte] => "application/octet-stream"
-    case actionResult: ActionResult => contentTypeInferrer(actionResult.body)
+    case actionResult: ActionResult =>
+      actionResult.headers.find {
+        case (name, value) => name.toLowerCase == "content-type"
+      }.getOrElse(("content-type", contentTypeInferrer(actionResult.body)))._2
+
     case _ => "text/html"
   }
 

--- a/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
@@ -37,6 +37,19 @@ class ActionResultServlet extends ScalatraServlet {
     Found("/ok")
   }
 
+  get("/contentType") {
+    val headerName =
+      if (params.getOrElse("lcase", "false") == "true")
+        "content-type"
+      else
+        "Content-Type"
+
+
+    Ok("Hello, world!", headers = Map(
+      headerName -> "application/vnd.ms-excel"
+    ))
+  }
+
   get("/custom-reason") {
     BadRequest(body = "abc", reason = "Bad Bad Bad")
   }
@@ -81,6 +94,18 @@ class ActionResultsSpec extends MutableScalatraSpec {
     "set the headers" in {
       get("/headers") {
         header("X-Something") mustEqual "Something"
+      }
+    }
+
+    "set the Content-Type header if it exists in the headers map" in {
+      get("/contentType") {
+        header("Content-Type") mustEqual "application/vnd.ms-excel;charset=UTF-8"
+      }
+    }
+
+    "set the Content-Type header if it's in lowercase in the headers map" in {
+      get("/contentType?lcase=true") {
+        header("Content-Type") mustEqual "application/vnd.ms-excel;charset=UTF-8"
       }
     }
   }


### PR DESCRIPTION
Previously if Content-Type header was set in the headers map for ActionResult,
it would be discarded and overriden by the header inferred using
contentTypeInferrer.

This change tries to infer the Content-Type from the headers map for
ActionResults, or if it isn't specified, falls back to inferring the
content type from the body.
