### PR TITLE
Fix synchronization for CookieSupport/DateUtil

### DIFF
--- a/core/src/main/scala/org/scalatra/CookieSupport.scala
+++ b/core/src/main/scala/org/scalatra/CookieSupport.scala
@@ -18,11 +18,11 @@ case class CookieOptions(
         encoding: String  = "UTF-8")
 
 object Cookie {
-  private[this] var _currentTimeMillis: Option[Long] = None
+  @volatile private[this] var _currentTimeMillis: Option[Long] = None
   def currentTimeMillis = _currentTimeMillis getOrElse System.currentTimeMillis
-  def currentTimeMillis_=(ct: Long) = synchronized { _currentTimeMillis = Some(ct) }
-  def freezeTime() = synchronized { _currentTimeMillis = Some(System.currentTimeMillis()) }
-  def unfreezeTime() = synchronized { _currentTimeMillis = None }
+  def currentTimeMillis_=(ct: Long) = _currentTimeMillis = Some(ct)
+  def freezeTime() = _currentTimeMillis = Some(System.currentTimeMillis())
+  def unfreezeTime() = _currentTimeMillis = None
   def formatExpires(date: Date) = DateUtil.formatDate(date, "EEE, dd MMM yyyy HH:mm:ss zzz")
 }
 case class Cookie(name: String, value: String)(implicit cookieOptions: CookieOptions = CookieOptions()) {

--- a/core/src/main/scala/org/scalatra/util/DateUtil.scala
+++ b/core/src/main/scala/org/scalatra/util/DateUtil.scala
@@ -4,11 +4,11 @@ import java.util.{TimeZone, Date}
 import java.text.SimpleDateFormat
 
 object DateUtil {
-  private[this] var _currentTimeMillis: Option[Long] = None
+  @volatile private[this] var _currentTimeMillis: Option[Long] = None
   def currentTimeMillis = _currentTimeMillis getOrElse System.currentTimeMillis
-  def currentTimeMillis_=(ct: Long) = synchronized { _currentTimeMillis = Some(ct) }
-  def freezeTime() = synchronized { _currentTimeMillis = Some(System.currentTimeMillis()) }
-  def unfreezeTime() = synchronized { _currentTimeMillis = None }
+  def currentTimeMillis_=(ct: Long) = _currentTimeMillis = Some(ct)
+  def freezeTime() = _currentTimeMillis = Some(System.currentTimeMillis())
+  def unfreezeTime() = _currentTimeMillis = None
   def formatDate(date: Date, format: String, timeZone: TimeZone = TimeZone.getTimeZone("GMT")) = {
     val df = new SimpleDateFormat(format)
     df.setTimeZone(timeZone)


### PR DESCRIPTION
While studying the Scalatra source tonight I came across a couple cases where synchronization was improperly used to update a shared value. The JMM only promises that a given thread will see the latest value of a variable if both write and read operations are properly synchronized. This pull request fixes the only two places that I found in Scalatra where this occurs.

More info: http://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html#incorrectlySync
