### PR TITLE
lookup should return null if broadcaster is not found

### DIFF
--- a/atmosphere/src/main/scala/org/atmosphere/cpr/ScalatraBroadcasterFactory.scala
+++ b/atmosphere/src/main/scala/org/atmosphere/cpr/ScalatraBroadcasterFactory.scala
@@ -92,7 +92,7 @@ class ScalatraBroadcasterFactory(cfg: AtmosphereConfig)(implicit wireFormat: Wir
       }
 
     }
-    store(id)
+    bOpt.getOrElse(null)
   }
 
   def lookup(id: Any): Broadcaster = lookup(id, false)


### PR DESCRIPTION
As defined in the BroadcasterFactory interface
