### PR TITLE
change validation.fail.toOption to use a fold for compatibility with scalaz7

### DIFF
--- a/commands/src/main/scala/org/scalatra/commands/binding.scala
+++ b/commands/src/main/scala/org/scalatra/commands/binding.scala
@@ -92,7 +92,7 @@ sealed trait Binding {
   def name: String = field.name
   def validation: FieldValidation[T] = field.value
   def value: Option[T] = field.value.toOption
-  def error: Option[ValidationError] = field.value.fail.toOption
+  def error: Option[ValidationError] = field.value.fold(_.some, _=>None)
 
   def isValid = validation.isSuccess
   def isInvalid = validation.isFailure

--- a/commands/src/main/scala/org/scalatra/commands/field.scala
+++ b/commands/src/main/scala/org/scalatra/commands/field.scala
@@ -416,7 +416,7 @@ class Field[A:Manifest](descr: FieldDescriptor[A], command: Command) {
   def validation: FieldValidation[A] = binding.field.value.asInstanceOf[FieldValidation[A]]
   def value: Option[A] = binding.field.value.toOption.asInstanceOf[Option[A]]
   def defaultValue: A = descr.defaultValue
-  def error: Option[ValidationError] = binding.field.value.fail.toOption
+  def error: Option[ValidationError] = binding.field.value.fold(_.some, _=>None)
   def original = binding.original
 
   def binding: Binding = command.bindings(name)


### PR DESCRIPTION
I'm attaching three changes which should allow a easy switch to scalaz7 sometime in the future.

One of the issues is that scalaz.Failure[A,B].fail has a very different meaning in scalaz 6 vs. scalaz 7.  In scalaz 6 it produces a FailProjection, in scalaz 7 it produces a Failure[Failure[A,B],Nothing].  It was being used to produce something to call toOption.  toOption has completely opposite meanings in the two different results.
