### PR TITLE
The book is no more, long live the guides!

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ class ScalatraExample extends ScalatraServlet {
 
 ## Documentation
 
-Please see [The Scalatra Book](http://www.scalatra.org/guides/) for more.
+Please see [The Scalatra Guides](http://www.scalatra.org/guides/) for more.
 
 
 ## Latest version


### PR DESCRIPTION
Text change, we don't want people now confusing the (now nonexistent) Scalatra Book, or the guides, with the new Manning book.
