### PR TITLE
scalatra-auth: Remove the dependency of scalatra-commands

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -79,7 +79,7 @@ object ScalatraBuild extends Build {
       description := "Scalatra authentication module",
       LsKeys.tags in LsKeys.lsync += "auth"
     )
-  ) dependsOn(scalatraCore % "compile;test->test;provided->provided", scalatraCommands)
+  ) dependsOn(scalatraCore % "compile;test->test;provided->provided")
 
 
   lazy val scalatraFileupload = Project(


### PR DESCRIPTION
As far as I can tell, scalatra-auth has no code dependency on scalatra-commands despite the sbt/pom dependency. scalatra-commands has a number of reasonably heavy-weight dependencies (scalaz/commons-validator) that I don't use in my project.

I've confirmed scalatra compiles and runs just fine with the dependency removed.
