### PR TITLE
Add ability to document API operations that support multiple content type responses

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -417,6 +417,7 @@ trait SwaggerOperation {
   def nickname: Option[String]
   def parameters: List[Parameter]
   def errorResponses: List[Error]
+  def supportedContentTypes: List[String]
 }
 case class Operation(httpMethod: HttpMethod,
                      responseClass: String,
@@ -425,7 +426,8 @@ case class Operation(httpMethod: HttpMethod,
                      deprecated: Boolean = false,
                      nickname: Option[String] = None,
                      parameters: List[Parameter] = Nil,
-                     errorResponses: List[Error] = Nil) extends SwaggerOperation
+                     errorResponses: List[Error] = Nil,
+                     supportedContentTypes: List[String]) extends SwaggerOperation
 trait SwaggerEndpoint[T <: SwaggerOperation] {
   def path: String
   def description: String

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -200,6 +200,7 @@ object SwaggerSupportSyntax {
     private[this] var _nickname: String = _
     private[this] var _parameters: List[Parameter] = Nil
     private[this] var _errorResponses: List[Error] = Nil
+    private[this] var _produces: List[String] = Nil
 
    def resultClass: String
 
@@ -227,6 +228,8 @@ object SwaggerSupportSyntax {
     def errors(errs: Error*): this.type = { _errorResponses :::= errs.toList; this }
     def error(err: Error): this.type = errors(err)
     def errorResponses: List[Error] = _errorResponses
+    def produces(values: String*): this.type = { _produces :::= values.toList; this}
+    def produces: List[String] = _produces
 
     def result: T
   }
@@ -241,7 +244,8 @@ object SwaggerSupportSyntax {
       deprecated,
       nickname,
       parameters,
-      errorResponses)
+      errorResponses,
+      produces)
   }
 }
 trait SwaggerSupportSyntax extends Initializable with CorsSupport { this: ScalatraBase with SwaggerSupportBase =>
@@ -250,6 +254,7 @@ trait SwaggerSupportSyntax extends Initializable with CorsSupport { this: Scalat
   protected def applicationName: Option[String] = None
   protected def applicationDescription: String
   protected def swaggerDefaultErrors: List[Error] = Nil
+  protected def swaggerDefaultProduces = List("application/json")
 
   private[this] def throwAFit =
     throw new IllegalStateException("I can't work out which servlet registration this is.")
@@ -457,11 +462,11 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
   protected implicit def operationBuilder2operation[T](bldr: SwaggerOperationBuilder[Operation]): Operation = bldr.result
   protected def apiOperation[T: Manifest](nickname: String): OperationBuilder = {
     registerModel[T]()
-    new OperationBuilder(DataType[T].name).nickname(nickname).errors(swaggerDefaultErrors:_*)
+    new OperationBuilder(DataType[T].name).nickname(nickname).errors(swaggerDefaultErrors:_*).produces(swaggerDefaultProduces:_*)
   }
   protected def apiOperation(nickname: String, model: Model): OperationBuilder = {
     registerModel(model)
-    new OperationBuilder(model.id).nickname(nickname).errors(swaggerDefaultErrors:_*)
+    new OperationBuilder(model.id).nickname(nickname).errors(swaggerDefaultErrors:_*).produces(swaggerDefaultProduces:_*)
   }
 
   /**
@@ -492,6 +497,7 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
       val summary = (route.metadata.get(Symbols.Summary) map (_.asInstanceOf[String])).orNull
       val notes = route.metadata.get(Symbols.Notes) map (_.asInstanceOf[String])
       val nick = route.metadata.get(Symbols.Nickname) map (_.asInstanceOf[String])
+      val produces = route.metadata.get(Symbols.Produces) map (_.asInstanceOf[List[String]]) getOrElse Nil
       Operation(
         httpMethod = method,
         responseClass = responseClass,
@@ -499,7 +505,8 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
         notes = notes,
         nickname = nick,
         parameters = theParams,
-        errorResponses = errors ::: swaggerDefaultErrors)
+        errorResponses = errors ::: swaggerDefaultErrors,
+        supportedContentTypes = produces ::: swaggerDefaultProduces)
     }
   }
 

--- a/swagger/src/main/scala/org/scalatra/swagger/package.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/package.scala
@@ -12,6 +12,7 @@ package object swagger {
     val Allows = Symbol("swagger.allows")
     val Operation = Symbol("swagger.extractOperation")
     val Description = Symbol("swagger.description")
+    val Produces = Symbol("swagger.produces")
     val AllSymbols = Set(Summary, Notes, Nickname, ResponseClass, Parameters, Errors, Endpoint, Allows, Operation)
   }
 


### PR DESCRIPTION
Exploit an undocumented feature in Swagger 1.1 that allows multiple content-type responses to be tried out
- relevant 'supportedContentTypes' field will be renamed to 'produces' in 1.2 spec (release not imminent)
- default behaviour if no 'produces' specified is to return 'application/json' as this is current behaviour of swagger-ui
