### PR TITLE
Fix atmosphere disconnect handling

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraAtmosphereHandler.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraAtmosphereHandler.scala
@@ -34,15 +34,13 @@ object ScalatraAtmosphereHandler {
     }
 
     def onDisconnect(event: AtmosphereResourceEvent) {
-      event.getResource.session.removeAttribute(org.scalatra.atmosphere.AtmosphereClientKey)
-      if (event.isCancelled) {
-        val disconnector = if (event.isCancelled) ClientDisconnected else ServerDisconnected
-        client(event.getResource) foreach (_.receive.lift(Disconnected(disconnector, Option(event.throwable))))
-        if (!event.getResource.isResumed) {
-           event.getResource.session.invalidate()
-         }
-
-      }
+      val disconnector = if (event.isCancelled) ClientDisconnected else ServerDisconnected
+      client(event.getResource) foreach (_.receive.lift(Disconnected(disconnector, Option(event.throwable))))
+      if (!event.getResource.isResumed) {
+         event.getResource.session.invalidate()
+       } else {
+         event.getResource.session.removeAttribute(org.scalatra.atmosphere.AtmosphereClientKey)
+       }
     }
 
     def onResume(event: AtmosphereResourceEvent) {}


### PR DESCRIPTION
Only remove session attribute _after_ the client is retrieved from the session and sent the `Disconnected` message.
Also removing the pointless first `isCancelled` check.
