### PR TITLE
Remove siasia SBT web plugin import

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -2,7 +2,6 @@ import sbt._
 import Keys._
 import scala.xml._
 import java.net.URL
-import com.github.siasia.WebPlugin.webSettings
 import ls.Plugin.LsKeys
 import org.scalatra.sbt.ScalatraPlugin.scalatraWithWarOverlays
 


### PR DESCRIPTION
It looks like the dependency was removed in 41688758629e8959137f04f8a60dd8a7e67e7846, but the import remained. This is giving me issues when building locally.
