### PR TITLE
Remove deprecation of the old FileUploadSupport

### DIFF
--- a/fileupload/src/main/scala/org/scalatra/fileupload/FileUploadSupport.scala
+++ b/fileupload/src/main/scala/org/scalatra/fileupload/FileUploadSupport.scala
@@ -21,9 +21,6 @@ import org.apache.commons.fileupload.{FileUploadException, FileUploadBase, FileI
    *
    * @note Once any handler with FileUploadSupport has accessed the request, the fileParams returned by FileUploadSupport will remain fixed for
    * the lifetime of the request. */
-@deprecated(message = "Deprecated in favor of Servlet 3.0 API's multipart features. " +
-                      "Please use org.scalatra.servlet.FileUploadSupport instead.",
-            since = "2.1.0")
 trait FileUploadSupport extends ServletBase {
   import FileUploadSupport._
 


### PR DESCRIPTION
### Guice users need the old FileUploadSupport

`org.scalatra.fileupload.FileUploadSupport` lets the Guice ServletModule users to handle multipart
uploads, whereas `org.scalatra.servlet.FileUploadSupport` does not.

Guice ServletModule does not work with the Servlet 3 multipart-parser implementations of Jetty 8 and Tomcat 7. This seems the be caused by the way Guice interacts with the servlet container: Guice handles HTTP requests in the filter context, while Jetty and Tomcat expect multipart requests to be handled within the servlet context.
#### Summary

I could not get Jetty or Tomcat to handle multipart uploads when I used `org.scalatra.servlet.FileUploadSupport` with Guice-configured Scalatra servlets. Consequently, I propose that we remove the `@Deprecation` status from `org.scalatra.fileupload.FileUploadSupport`. 
