### PR TITLE
Provide a way to create own i18n Message Interface Edit (2.9)

### DIFF
--- a/core/src/main/scala/org/scalatra/i18n/I18nSupport.scala
+++ b/core/src/main/scala/org/scalatra/i18n/I18nSupport.scala
@@ -41,8 +41,16 @@ trait I18nSupport {
 
   before() {
     request(LocaleKey) = resolveLocale
-    request(MessagesKey) = Messages(locale)
+    request(MessagesKey) = provideMessages(locale)
   }
+
+  /**
+   * Provides a default Message resolver
+   *
+   * @param locale Locale used to create instance
+   * @return a new instance of Messages, override to provide own implementation
+   */
+  def provideMessages(locale:Locale) : Messages = Messages(locale)
 
   /*
   * Resolve Locale based on HTTP request parameter or Cookie


### PR DESCRIPTION
The current i18n trait does not provide a way to create an own Message instance (with different Resource Bundles then default). This pull request provides an override-able default Method
