### PR TITLE
atmosphere-redis plugin support and moved ScalatraBroadcaster into a trait

### DIFF
--- a/atmosphere/src/main/scala/org/atmosphere/cpr/ScalatraBroadcasterFactory.scala
+++ b/atmosphere/src/main/scala/org/atmosphere/cpr/ScalatraBroadcasterFactory.scala
@@ -7,14 +7,14 @@ import collection.mutable
 import java.util.concurrent.ConcurrentHashMap
 import org.atmosphere.di.InjectorProvider
 import java.util.UUID
-import org.scalatra.atmosphere.{WireFormat, ScalatraBroadcaster}
+import org.scalatra.atmosphere.{DefaultScalatraBroadcaster, WireFormat, ScalatraBroadcaster}
 import collection.JavaConverters._
 import scala.collection.concurrent.{Map => ConcurrentMap}
 
 object ScalatraBroadcasterFactory {
 
 }
-class ScalatraBroadcasterFactory(cfg: AtmosphereConfig)(implicit wireFormat: WireFormat, system: ActorSystem) extends BroadcasterFactory {
+class ScalatraBroadcasterFactory(cfg: AtmosphereConfig, bc: Class[_<:ScalatraBroadcaster] = classOf[DefaultScalatraBroadcaster])(implicit wireFormat: WireFormat, system: ActorSystem) extends BroadcasterFactory {
   BroadcasterFactory.setBroadcasterFactory(this, cfg)
 
   private[this] val logger = Logger[ScalatraBroadcasterFactory]
@@ -23,7 +23,7 @@ class ScalatraBroadcasterFactory(cfg: AtmosphereConfig)(implicit wireFormat: Wir
   private def createBroadcaster(c: Class[_<:Broadcaster], id: Any): Broadcaster = {
     try {
       val b: Broadcaster = if (classOf[ScalatraBroadcaster].isAssignableFrom(c)) {
-        new ScalatraBroadcaster(id.toString, cfg)
+        bc.getConstructor(classOf[String], classOf[AtmosphereConfig], classOf[WireFormat], classOf[ActorSystem]).newInstance(id.toString, cfg, wireFormat, system).asInstanceOf[Broadcaster]
       } else {
         c.getConstructor(classOf[String], classOf[AtmosphereConfig]).newInstance(id.toString, cfg)
 

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -31,6 +31,9 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
   private[this] val logger = Logger[this.type]
 
   private[this] val _defaultWireformat = new JacksonSimpleWireformat
+
+  protected var scalatraBroadcasterClass: Class[_<:ScalatraBroadcaster] = classOf[DefaultScalatraBroadcaster]
+
   implicit protected def wireFormat: WireFormat = _defaultWireformat
 
   implicit def json2JsonMessage(json: JValue): OutboundMessage = JsonMessage(json)
@@ -141,7 +144,7 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
   } yield matched).headOption
 
   private[this] def configureBroadcasterFactory() {
-    val factory = new ScalatraBroadcasterFactory(atmosphereFramework.getAtmosphereConfig)
+    val factory = new ScalatraBroadcasterFactory(atmosphereFramework.getAtmosphereConfig, scalatraBroadcasterClass)
     atmosphereFramework.setBroadcasterFactory(factory)
     atmosphereFramework.setDefaultBroadcasterClassName(classOf[ScalatraBroadcaster].getName)
   }

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/DefaultScalatraBroadcaster.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/DefaultScalatraBroadcaster.scala
@@ -1,0 +1,14 @@
+package org.scalatra.atmosphere
+
+import _root_.akka.actor._
+import org.atmosphere.cpr._
+import java.util.concurrent.ConcurrentLinkedQueue
+
+
+final class DefaultScalatraBroadcaster(id: String, config: AtmosphereConfig)
+                                      (implicit wireFormat: WireFormat, system: ActorSystem)
+  extends DefaultBroadcaster(id, config) with ScalatraBroadcaster {
+  protected var _resources: ConcurrentLinkedQueue[AtmosphereResource] = resources
+  protected var _wireFormat: WireFormat = wireFormat
+  protected implicit var _actorSystem: ActorSystem = system
+}

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/RedisScalatraBroadcaster.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/RedisScalatraBroadcaster.scala
@@ -1,0 +1,15 @@
+package org.scalatra.atmosphere
+
+import _root_.akka.actor._
+import org.atmosphere.cpr._
+import java.util.concurrent.ConcurrentLinkedQueue
+import org.atmosphere.plugin.redis.RedisBroadcaster
+
+
+final class RedisScalatraBroadcaster(id: String, config: AtmosphereConfig)
+                                      (implicit wireFormat: WireFormat, system: ActorSystem)
+  extends RedisBroadcaster(id, config) with ScalatraBroadcaster {
+  protected var _resources: ConcurrentLinkedQueue[AtmosphereResource] = resources
+  protected var _wireFormat: WireFormat = wireFormat
+  protected implicit var _actorSystem: ActorSystem = system
+}

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraBroadcaster.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraBroadcaster.scala
@@ -5,19 +5,21 @@ import _root_.akka.actor._
 import collection.JavaConverters._
 import grizzled.slf4j.Logger
 import org.atmosphere.cpr._
-import org.json4s.Formats
 import concurrent.{ExecutionContext, Future}
+import java.util.concurrent.ConcurrentLinkedQueue
 
 
-final class ScalatraBroadcaster(id: String, config: AtmosphereConfig)(implicit wireFormat: WireFormat, system: ActorSystem) extends DefaultBroadcaster(id, config) {
+trait ScalatraBroadcaster extends Broadcaster {
 
   private[this] val logger: Logger = Logger[ScalatraBroadcaster]
+  protected var _resources: ConcurrentLinkedQueue[AtmosphereResource]
+  protected var _wireFormat: WireFormat
+  protected implicit var _actorSystem: ActorSystem
 
   def broadcast[T <: OutboundMessage](msg: T, clientFilter: ClientFilter)(implicit executionContext: ExecutionContext): Future[T] = {
-    val selectedResources = resources.asScala map (_.client) filter clientFilter
+    val selectedResources = _resources.asScala map (_.client) filter clientFilter
     logger.info("Sending %s to %s".format(msg, selectedResources.map(_.uuid)))
-    broadcast(wireFormat.render(msg), selectedResources.map(_.resource).toSet.asJava).map(_ => msg)
+    broadcast(_wireFormat.render(msg), selectedResources.map(_.resource).toSet.asJava).map(_ => msg)
   }
-
 
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -94,7 +94,7 @@ object ScalatraBuild extends Build {
     base = file("atmosphere"),
     settings = scalatraSettings ++ Seq(
       libraryDependencies <++= scalaVersion(sv => Seq(akkaActor(sv), akkaTestkit(sv) % "test")),
-      libraryDependencies ++= Seq(atmosphereRuntime, atmosphereClient % "test", jettyWebsocket % "test"),
+      libraryDependencies ++= Seq(atmosphereRuntime, atmosphereRedis, atmosphereClient % "test", jettyWebsocket % "test"),
       description := "Atmosphere integration for scalatra",
       LsKeys.tags in LsKeys.lsync ++= Seq("atmosphere", "comet", "sse", "websocket")
     )
@@ -249,6 +249,7 @@ object ScalatraBuild extends Build {
     lazy val atmosphereRuntime          =  "org.atmosphere"          % "atmosphere-runtime"  % "1.0.12"
     lazy val atmosphereJQuery           =  "org.atmosphere"          % "atmosphere-jquery"   % "1.0.12" artifacts(Artifact("atmosphere-jquery", "war", "war"))
     lazy val atmosphereClient           =  "org.atmosphere"          % "wasync"              % "1.0.0.RC1"
+    lazy val atmosphereRedis            =  "org.atmosphere"          % "atmosphere-redis"    % "1.0.12"
     lazy val base64                     =  "net.iharder"             %  "base64"             % "2.3.8"
     lazy val commonsFileupload          =  "commons-fileupload"      %  "commons-fileupload" % "1.2.2"
     lazy val commonsIo                  =  "commons-io"              %  "commons-io"         % "2.4"


### PR DESCRIPTION
This is my first attempt, so hopefully it doesn't look too bad! My main motivation was just to get the atmosphere-redis plugin working. I don't know if the plugin is something that should stay out of the core but I still needed to make the ScalatraBroadcaster more flexible. That is why I moved it into a trait. 

If this is something that everyone would be interested in, I would be happy to clean it up more or do anything else desired.

I think this might mainly be for casualJim's review, as I was told the atmosphere support has mainly been his baby.

Any comments/suggestions would be appreciated!

Commit log:
Made ScalatraBroadcaster into a trait for custom broadcasters. Moved some logic into a DefaultScalatraBroadcaster that gets used by default. Additionally made a RedisScalatraBroadcaster that uses the atmosphere-redis plugin. Custom broadcasters can be used by changing the new scalatraBroadcasterClass member in the AtmosphereSupport trait.
