### PR TITLE
Run status code handlers when halt()'d (fixes #308)

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -188,9 +188,16 @@ trait ScalatraBase extends ScalatraContext with CoreDsl with DynamicScope with I
 
   private[this] def cradleHalt(body: => Any, error: Throwable => Any) = {
     try { body } catch {
-      case e: HaltException => handleStatusCode(extractStatusCode(e)) match {
-        case Some(r) => renderResponse(r)
-        case _       => renderHaltException(e)
+      case e: HaltException => {
+        try {
+          handleStatusCode(extractStatusCode(e)) match {
+            case Some(result) => renderResponse(result)
+            case _            => renderHaltException(e)
+          }
+        } catch {
+          case e: HaltException => renderHaltException(e)
+          case e: Throwable     => error(e)
+        }
       }
       
       case e: Throwable => error(e)

--- a/core/src/test/scala/org/scalatra/StatusCodeHandlerTest.scala
+++ b/core/src/test/scala/org/scalatra/StatusCodeHandlerTest.scala
@@ -26,6 +26,10 @@ class StatusCodeHandlerTest extends ScalatraFunSuite {
       halt(401)
     }
 
+    get("/traphalt") {
+      halt(418, "I'm a teapot")
+    }
+
     trap(400 to 402) {
       status = 200
       "400s"
@@ -33,6 +37,10 @@ class StatusCodeHandlerTest extends ScalatraFunSuite {
     
     trap(500) {
       "internal error"
+    }
+
+    trap(418) {
+      halt(404, "404")
     }
   }
 
@@ -92,6 +100,13 @@ class StatusCodeHandlerTest extends ScalatraFunSuite {
     get("/base/halt401") {
       status should equal(200)
       body should equal("400s")
+    }
+  }
+
+  test("halts from trap handler") {
+    get("/base/traphalt") {
+      status should equal(404)
+      body should equal("404")
     }
   }
 }


### PR DESCRIPTION
This fixes #308 by trying to first run status code handlers whenever an action halt()'s.

If there isn't any matching status code handlers, will render halt exception normally.
