### PR TITLE
Fix issue #321: the result of a Future can be another Future, so we unroll them until we have an actual result

### DIFF
--- a/core/src/main/scala/org/scalatra/FutureSupport.scala
+++ b/core/src/main/scala/org/scalatra/FutureSupport.scala
@@ -72,28 +72,36 @@ trait FutureSupport extends AsyncSupport {
       def onStartAsync(event: AsyncEvent) {}
     })
 
-    f onComplete {
-      case t ⇒ {
-        withinAsyncContext(context) {
-          if (gotResponseAlready.compareAndSet(false, true)) {
-            try {
-              t map { result ⇒
-                renderResponse(result)
-              } recover {
-                case e: HaltException ⇒
-                  renderHaltException(e)
-                case e ⇒
-                  try {
-                    renderResponse(errorHandler(e))
-                  } catch {
-                    case e: Throwable =>
-                      ScalatraBase.runCallbacks(Failure(e))
-                      renderUncaughtException(e)
-                      ScalatraBase.runRenderCallbacks(Failure(e))
-                  }
+    renderFutureResult(f)
+
+    def renderFutureResult(f: Future[_]) {
+      f onComplete {
+        // Loop until we have a non-future result
+        case Success(f2: Future[_]) => renderFutureResult(f2)
+        case Success(r: AsyncResult) => renderFutureResult(r.is)
+
+        case t ⇒ {
+          withinAsyncContext(context) {
+            if (gotResponseAlready.compareAndSet(false, true)) {
+              try {
+                t map { result ⇒
+                  renderResponse(result)
+                } recover {
+                  case e: HaltException ⇒
+                    renderHaltException(e)
+                  case e ⇒
+                    try {
+                      renderResponse(errorHandler(e))
+                    } catch {
+                      case e: Throwable =>
+                        ScalatraBase.runCallbacks(Failure(e))
+                        renderUncaughtException(e)
+                        ScalatraBase.runRenderCallbacks(Failure(e))
+                    }
+                }
+              } finally {
+                context.complete()
               }
-            } finally {
-              context.complete()
             }
           }
         }

--- a/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
@@ -28,6 +28,18 @@ class AkkaSupportServlet extends ScalatraServlet with FutureSupport {
     "redirected"
   }
 
+  get("/future") {
+    Future({
+      "future"
+    })
+  }
+
+  get("/future/future") {
+    Future({ "in the " }) map ((s: String) =>
+      Future({ s + "future"})
+    )
+  }
+
   asyncGet("/working") {
     "the-working-reply"
   }
@@ -103,6 +115,18 @@ class AkkaSupportSpec extends MutableScalatraSpec {
       get("/redirect") {
         status must_== 302
         response.header("Location") must_== (baseUrl + "/redirected")
+      }
+    }
+
+    "render the result of a future" in {
+      get("/future") {
+        body mustEqual "future"
+      }
+    }
+
+    "render the result of a future returning a future" in {
+      get("/future/future") {
+        body mustEqual "in the future"
       }
     }
   }


### PR DESCRIPTION
Recursively call onComplete when a Future results in another Future or AsyncResult, until we have an actual result which can be rendered in the servlet response.
