### PR TITLE
Allow I18nScalateSupport everywhere ScalateSupport is allowed

### DIFF
--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateI18nSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateI18nSupport.scala
@@ -13,10 +13,8 @@ import javax.servlet.FilterConfig
 import org.fusesource.scalate.TemplateEngine
 import i18n.Messages
 import java.io.PrintWriter
-import servlet.ServletBase
 
 trait ScalateI18nSupport extends ScalateSupport with I18nSupport {
-  this: ServletBase =>
 
   /*
    * Binding done here seems to work all the time. 


### PR DESCRIPTION
At the moment scalate with I18n support is only limited to `ScalatraServlet` this should allow to use i18n everywhere where scalate is used, for instance `ScalatraFilter`
