### PR TITLE
Scalatra always returns Content-Type with charset=UTF-8

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -106,7 +106,6 @@ trait ScalatraBase extends ScalatraContext with CoreDsl with DynamicScope with I
   override def handle(request: HttpServletRequest, response: HttpServletResponse) {
     //    val realMultiParams = request.multiParameters
     request(CookieSupport.SweetCookiesKey) = new SweetCookies(request.cookies, response)
-    response.characterEncoding = Some(defaultCharacterEncoding)
 
     withRequestResponse(request, response) {
       //      request(MultiParamsKey) = MultiMap(Map() ++ realMultiParams)
@@ -438,8 +437,14 @@ trait ScalatraBase extends ScalatraContext with CoreDsl with DynamicScope with I
         case (name, value) => response.addHeader(name, value)
       }
       actionResult.body
-    case x =>
+    case x => {
+      response.contentType.foreach { ct =>
+        if(ct.indexOf(";charset=") < 0){
+          response.characterEncoding = Some(defaultCharacterEncoding)
+        }
+      }
       response.writer.print(x.toString)
+    }
   }
 
   /**


### PR DESCRIPTION
Scalatra set UTF-8 as response charset at first. So Content-Type header of response always contains `;charset=UTF-8`.

For example, in the cases of following, I expect Content-Type header is `image/jpeg`, but in fact, Scalatra returns `image/jpeg; charset=UTF-8`.

``` scala
get("/images/avater"){
  val bytes: Array[Byte] = ...
  contentType = "image/jpeg"
  bytes
}
```

To fix this problem, I changed `ScalatraBase` to set response charset just before rendering response only when it's not specified. 
