### PR TITLE
Scalate template path should be normalized

### DIFF
--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
@@ -243,7 +243,7 @@ trait ScalateSupport extends ScalatraKernel {
     val finder = new TemplateFinder(templateEngine) {
       override lazy val extensions = extensionSet
     }
-    finder.findTemplate("/"+path) orElse
+    finder.findTemplate(("/"+path).replaceAll("//", "/")) orElse
       finder.findTemplate("/%s/%s".format(path, defaultIndexName))
   }
 


### PR DESCRIPTION
```
findTemplate("/root/index.html.spp")
```

Scalate could not find template, because template path is invalid. It should be normalized "/".

```
2013-11-20 16:35:45,098 DEBUG [qtp629428158-20] o.f.s.s.ServletResourceLoader [Logging.scala:143] realPath for: /WEB-INF/views//root/index.html.ssp is: null
2013-11-20 16:35:45,100 DEBUG [qtp629428158-20] o.f.s.u.ResourceLoader [Logging.scala:143] Trying to load uri: /WEB-INF/views//root/index.html.ssp
```
