### PR TITLE
Bumping Atmosphere to latest version, 2.0.5

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -342,7 +342,7 @@ object ScalatraBuild extends Build {
       case _                            => "1.0.1"
     }
 
-    private val atmosphereVersion = "2.0.3"
+    private val atmosphereVersion = "2.0.5"
 
     private val atmosphereCompatVersion = "2.0.0"
 


### PR DESCRIPTION
Current Scalatra Atmosphere support in 2.3.x is Atmo 2.0.3. 

Current Atmosphere version is 2.0.5

Issues fixed for 2.0.4 and 2.0.5 are at:

https://github.com/Atmosphere/atmosphere/issues?labels=2.0.4&milestone=&page=1&state=closed
https://github.com/Atmosphere/atmosphere/issues?labels=2.0.5&milestone=&page=1&state=closed
