### PR TITLE
Correcting CSS mime types, fixes #349.

### DIFF
--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -36,7 +36,7 @@ trait ApiFormats extends ScalatraBase {
    */
   val formats: concurrent.Map[String, String] = new ConcurrentHashMap[String, String](Map(
     "atom" -> "application/atom+xml",
-    "css" -> "text/stylesheet",
+    "css" -> "text/css",
     "flv" -> "video/x-flv",
     "html" -> "text/html",
     "html5" -> "text/html",
@@ -73,7 +73,7 @@ trait ApiFormats extends ScalatraBase {
     "text/html" -> "html",
     "text/javascript" -> "json",
     "text/plain" -> "txt",
-    "text/stylesheet" -> "css",
+    "text/css" -> "css",
     "video/x-flv" -> "flv"
   ).asJava).asScala
 


### PR DESCRIPTION
Stylesheet MIME is text/css, as per http://en.wikipedia.org/wiki/Internet_media_type#Type_text
