### PR TITLE
fixed ScalatraServlet.requestPath for encoded unicode URI

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -27,10 +27,10 @@ object ScalatraServlet {
   }
 
   def requestPath(uri: String, idx: Int): String = {
-    val u2 = (uri.blankOption map { _.substring(idx) } flatMap(_.blankOption) getOrElse "/")
+    val u1 = UriDecoder.firstStep(uri)
+    val u2 = (u1.blankOption map { _.substring(idx) } flatMap(_.blankOption) getOrElse "/")
     val pos = u2.indexOf(';')
-    val u3 = if (pos > -1) u2.substring(0, pos) else u2
-    UriDecoder.firstStep(u3)
+    if (pos > -1) u2.substring(0, pos) else u2
   }
 }
 

--- a/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
+++ b/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
@@ -1,0 +1,20 @@
+package org.scalatra
+
+import org.scalatest.matchers.MustMatchers
+import org.scalatest._
+
+class ScalatraServletRequestPathSpec extends WordSpec with MustMatchers {
+
+  "a ScalatraServlet requestPath" should {
+
+    "be extracted properly from encoded url" in {
+      ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/")
+      ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/тест/")
+    }
+
+    "be extracted properly from decoded url" in {
+      ScalatraServlet.requestPath("/тест/", 5) must equal("/")
+      ScalatraServlet.requestPath("/тест/тест/", 5) must equal("/тест/")
+    }
+  }
+}


### PR DESCRIPTION
There was problem with unicode servlet mappings like this

``` scala
context.mount(new TestServlet, "тест")
```

The issue is that requestPath tried first remove context and servlet paths from the uri and then decode the result, it works for latin servlet paths, but failed for unicode. You need first decode the uri and then remove context and servlet paths from it to result the requestPath.

Here is the fix and test for it.
