### PR TITLE
When submodels were computed, the known models were not removed from that set. 

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -61,7 +61,7 @@ object Swagger {
           case descriptor: ClassDescriptor =>
             val ctorModels = descriptor.mostComprehensive.filterNot(_.isPrimitive)
             val propModels = descriptor.properties.filterNot(p => p.isPrimitive || ctorModels.exists(_.name == p.name))
-            val subModels = (ctorModels.map(_.argType) ++ propModels.map(_.returnType)).toSet
+            val subModels = (ctorModels.map(_.argType) ++ propModels.map(_.returnType)).toSet -- known
             val topLevel = for {
               tl <- subModels + descriptor.erasure
               if  !(tl.isCollection || tl.isMap || tl.isOption)

--- a/swagger/src/test/scala/org/scalatra/swagger/ModelCollectionSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/ModelCollectionSpec.scala
@@ -11,7 +11,7 @@ object ModelCollectionSpec {
   case class Name(value: String)
   case class Sequence(value: Long)
   case class TaggedThing(id: Long, tag: Tag, created: Date)
-  case class Asset(name: String, filename: String, id: Option[Int])
+  case class Asset(name: String, filename: String, id: Option[Int], relatedAsset: Asset)
 
   val taggedThingModels = Set(Swagger.modelToSwagger[Tag], Swagger.modelToSwagger[Name], Swagger.modelToSwagger[Sequence], Swagger.modelToSwagger[TaggedThing])
   val onlyPrimitivesModel = Swagger.modelToSwagger[OnlyPrimitives].get


### PR DESCRIPTION
This pull request removes known models from subModels and also adds a self referential field to a model in the existing ModelCollectionSpec test case
