### PR TITLE
Fix ClassCastException to Nothing$ because of incorrectly infered type

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereClient.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereClient.scala
@@ -19,7 +19,7 @@ object AtmosphereClient {
     val norm = if (!pth.endsWith("/*")) {
       if (!pth.endsWith("/")) pth + "/*" else "*"
     } else pth
-    val res = BroadcasterFactory.getDefault.lookup(norm)
+    val res: Broadcaster = BroadcasterFactory.getDefault.lookup(norm)
     if (res.isInstanceOf[ScalatraBroadcaster]) Option(res).map(_.asInstanceOf[ScalatraBroadcaster])
     else None
   }


### PR DESCRIPTION
When this code is ran ClassCastException gets thrown:
`java.lang.ClassCastException: org.scalatra.atmosphere.DefaultScalatraBroadcaster cannot be cast to scala.runtime.Nothing$`

This happens because [this](https://github.com/Atmosphere/atmosphere/commit/7e7f44579a75210a69055b8ec619214d2cf34618#diff-59efe98a5cb17cb15910bd0109763c02) change introduced Generic type inference in Java
