### PR TITLE
Add support for configuring RedisScalatraBroadcaster

### DIFF
--- a/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
+++ b/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
@@ -1,0 +1,37 @@
+package org.atmosphere.cpr
+
+import org.scalatra.atmosphere.{RedisScalatraBroadcaster, ScalatraBroadcaster}
+import java.net.URI
+
+trait BroadcasterConf {
+  def broadcasterClass: Class[_<:ScalatraBroadcaster]
+  def uri: URI
+  def extraSetup: Broadcaster => Unit // To perform optional plugin-specific Broadcaster setup
+}
+
+/**
+ *
+ * Basic Configuration-holder for Scalatra Atmosphere Broadcaster configuration
+ * @param broadcasterClass Class[_<:ScalatraBroadcaster]
+ * @param uri [[URI]] defaults to http://127.0.0.1
+ * @param extraSetup Broadcaster => Unit Function that is passed an initialized [[Broadcaster]] in order to allow for
+ *                   optional plugin-specific Broadcaster setup. Defaults to doing nothing.
+ */
+sealed case class ScalatraBroadcasterConfig(broadcasterClass: Class[_<:ScalatraBroadcaster],
+                                            uri: URI = URI.create("http://127.0.0.1"),
+                                            extraSetup: Broadcaster => Unit = { b => }) extends BroadcasterConf
+
+/**
+ * Convenient configuration class for RedisBroadcaster
+ *
+ * Using this class will automatically take care of setting Redis auth on the underlying
+ * RedisBroadcaster if the auth parameter is given an argument
+ *
+ * @param uri [[URI]] for the Redis Server. Defaults to redis://127.0.0.1:6379
+ * @param auth An Option[String] if the Redis Server requires a password. Defaults to None
+ */
+sealed case class RedisScalatraBroadcasterConfig(uri: URI = URI.create("redis://127.0.0.1:6379"), auth: Option[String] = None) extends BroadcasterConf {
+  final val broadcasterClass = classOf[RedisScalatraBroadcaster]
+  final val extraSetup = { b: Broadcaster =>
+    auth.foreach(b.asInstanceOf[RedisScalatraBroadcaster].setAuth(_)) }
+}

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -31,7 +31,12 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
 
   private[this] val _defaultWireformat = new JacksonSimpleWireformat
 
-  protected var scalatraBroadcasterClass: Class[_<:ScalatraBroadcaster] = classOf[DefaultScalatraBroadcaster]
+  /**
+   * Override this to use another ScalaBroadcaster like RedisScalatraBroadcaster
+   *
+   * Example: RedisScalatraBroadcasterConfig(URI.create("redis://127.0.0.1"), Some("password"))
+   */
+  protected val broadcasterConfig: BroadcasterConf = ScalatraBroadcasterConfig(classOf[DefaultScalatraBroadcaster])
 
   implicit protected def wireFormat: WireFormat = _defaultWireformat
 
@@ -143,8 +148,10 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
   } yield matched).headOption
 
   private[this] def configureBroadcasterFactory() {
-    val factory = new ScalatraBroadcasterFactory(atmosphereFramework.getAtmosphereConfig, scalatraBroadcasterClass)
-    atmosphereFramework.setDefaultBroadcasterClassName(scalatraBroadcasterClass.getName)
+    val factory = new ScalatraBroadcasterFactory(
+      atmosphereFramework.getAtmosphereConfig,
+      broadcasterConfig)
+    atmosphereFramework.setDefaultBroadcasterClassName(broadcasterConfig.broadcasterClass.getName)
     atmosphereFramework.setBroadcasterFactory(factory)
   }
 


### PR DESCRIPTION
Main focus was allowing developers to override a single val inherited from AtmosphereSupport
if they want to use RedisBroadcaster and still be able to configure their own URI, but I also
wanted to allow them to set a password when configuring in case their RedisServer requires one.

In order to accommodate the fact that RedisBroadcaster needs to have `setAuth` called after
initialization (I think some other Broadcaster-related Atmosphere plugins follow this pattern),
`BroadcasterConf`  objects take a `extraSetup: Broadcaster => Unit` parameter that gets
called by `ScalatraBroadcasterFactory` after the `Broadcaster` object has been allocated
and `initialize`d.
