### PR TITLE
Fix UninitializedFieldError when using RedisScalatraBroadcasterConfig

### DIFF
--- a/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
+++ b/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
@@ -31,7 +31,7 @@ sealed case class ScalatraBroadcasterConfig(broadcasterClass: Class[_<:ScalatraB
  * @param auth An Option[String] if the Redis Server requires a password. Defaults to None
  */
 sealed case class RedisScalatraBroadcasterConfig(uri: URI = URI.create("redis://127.0.0.1:6379"), auth: Option[String] = None) extends BroadcasterConf {
-  final val broadcasterClass = classOf[RedisScalatraBroadcaster]
-  final val extraSetup = { b: Broadcaster =>
+  final def broadcasterClass = classOf[RedisScalatraBroadcaster]
+  final def extraSetup = { b: Broadcaster =>
     auth.foreach(b.asInstanceOf[RedisScalatraBroadcaster].setAuth(_)) }
 }


### PR DESCRIPTION
Sorry about this additional pull. I forgot that I hadn't committed + pushed this
change to my branch before issuing the pull request yesterday and found it
today when cleaning branches.

Overriding the trait abstract `def`s using `val`s in an extending class the previous way
causes `UninitializedFieldError` because it gets late initialized, and extending an
anonymous class (e.g.`extends { val ... } with BroadcasterConf`) breaks the nice 
auto-companion object constructor provided by using a `case class` , so I made changes
to implement the abstract `def`s as  `def`s in the `RedisScalatraBroadcasterConfig` class.
