### PR TITLE
improve error message when no Get route is defined while using AtmosphereSupport

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -133,7 +133,10 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
     }
   }
 
-  private[this] def atmosphereRoutes = routes.methodRoutes(Get).filter(_.metadata.contains('Atmosphere))
+  private[this] def noGetRoute = sys.error("You are using the AtmosphereSupport without defining any Get route," +
+     "you should get rid of it.")
+
+  private[this] def atmosphereRoutes = routes.methodRoutes.getOrElse(Get, noGetRoute).filter(_.metadata.contains('Atmosphere))
 
   private[this] def atmosphereRoute(req: HttpServletRequest) = (for {
     route <- atmosphereRoutes.toStream


### PR DESCRIPTION
This isn't supposed to happen, but if it does it saves you some time.
