### PR TITLE
simplify TrackMessageSizeInterceptor configuration

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -96,11 +96,19 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
     }
   }
 
+  /** Decides whether a [[TrackMessageSizeInterceptor]] should be added to the atmosphere framework.
+    * This method looks for the [[TrackMessageSize]] setting in the [[ServletConfig]] but can be
+    * overridden.
+    */
+  protected def trackMessageSize(cfg: ServletConfig) : Boolean = {
+    cfg.getInitParameter(TrackMessageSize).blankOption.exists(_.toCheckboxBool)
+  }
+
   protected def configureInterceptors(cfg: ServletConfig) = {
     atmosphereFramework.interceptor(new SessionCreationInterceptor)
     if (cfg.getInitParameter(ApplicationConfig.PROPERTY_NATIVE_COMETSUPPORT).isBlank)
       cfg.getServletContext.setInitParameter(ApplicationConfig.PROPERTY_NATIVE_COMETSUPPORT, "true")
-    if (cfg.getInitParameter(TrackMessageSize).blankOption.map(_.toCheckboxBool).getOrElse(false))
+    if (trackMessageSize(cfg))
       atmosphereFramework.interceptor(new TrackMessageSizeInterceptor)
   }
 


### PR DESCRIPTION
I figured a better way of doing this... I can rebase if you agree this is better.
The previous version let the servlet configuration override `trackMessageSize` method - i.e if `trackMessageSize` is intentionally set to false and the servlet configuration is true then the interceptor will be nonetheless added.
I believe that one way of configuring this would be to set it globally in the scalatra bootstrap and then fine tune it per servlet.
