### PR TITLE
Update ScentrySupport to avoid compiler warnings

### DIFF
--- a/auth/src/main/scala/org/scalatra/auth/ScentrySupport.scala
+++ b/auth/src/main/scala/org/scalatra/auth/ScentrySupport.scala
@@ -49,7 +49,7 @@ trait ScentrySupport[UserType <: AnyRef] extends Initializable {
     registerAuthStrategies
   }
 
-  protected def configureScentry = {
+  protected def configureScentry() = {
 
   }
 
@@ -57,7 +57,7 @@ trait ScentrySupport[UserType <: AnyRef] extends Initializable {
    * Override this method to register authentication strategies specific to this servlet.
    *     registerAuthStrategy('UserPassword, app => new UserPasswordStrategy(app))
    */
-  protected def registerAuthStrategies = {
+  protected def registerAuthStrategies() = {
 
   }
 


### PR DESCRIPTION
Overriding configureScentry and registerAuthStrategies methods cause "side-effecting nullary method" or "non-nullary method overrides nullary method" warnings depending on whether we omit parenthesis or not.
With this simple update that issue can be avoided without breaking backwards compatibility.
