### PR TITLE
SizeConstraintExceededException params fix

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/SizeConstraintExceededException.scala
+++ b/core/src/main/scala/org/scalatra/servlet/SizeConstraintExceededException.scala
@@ -1,4 +1,4 @@
 package org.scalatra.servlet
 
-class SizeConstraintExceededException(message: String, t: Throwable) extends Exception
+class SizeConstraintExceededException(message: String, t: Throwable) extends Exception(message, t)
 


### PR DESCRIPTION
Class `SizeConstraintExceededException` must pass its params `message` and `t` to the constructor for superclass `Exception`.
