### PR TITLE
Honouring request's Content-Type header when parsing params and request body for command object

### DIFF
--- a/commands/src/main/scala/org/scalatra/commands/JacksonJsonParsing.scala
+++ b/commands/src/main/scala/org/scalatra/commands/JacksonJsonParsing.scala
@@ -2,7 +2,6 @@ package org.scalatra
 package commands
 
 import json.{JacksonJsonValueReaderProperty, JacksonJsonSupport}
-import grizzled.slf4j.Logger
 import javax.servlet.http.HttpServletRequest
 
 trait JacksonJsonParsing extends CommandSupport with JacksonJsonValueReaderProperty { self: JacksonJsonSupport with CommandSupport =>
@@ -10,7 +9,12 @@ trait JacksonJsonParsing extends CommandSupport with JacksonJsonValueReaderPrope
 
 
   override protected def bindCommand[T <: CommandType](newCommand: T)(implicit request: HttpServletRequest, mf: Manifest[T]): T = {
-    format match {
+    val requestFormat = request.contentType match {
+      case Some(contentType) => mimeTypes.getOrElse(contentType, format)
+      case None => format
+    }
+
+    requestFormat match {
       case "json" | "xml" => newCommand.bindTo(parsedBody(request), multiParams(request), request.headers)
       case _ => newCommand.bindTo(params(request), multiParams(request), request.headers)
     }


### PR DESCRIPTION
Wanting to test content negotiation whereby a request could be sent as a form post (i.e. with a Content-Type request header of "application/x-www-form-urlencoded") but with the user-agent requesting that the response format be json (i.e. with an Accept request header of "application/json") I was finding that the command object could not be parsed from the submitted form data because JacksonJsonParsing.bindCommand was assuming the request's format was defined by the Accept header rather than the Content-Type header.

This meant that the command object failed to populate from the posted form values because it was looking for a JSON string, and therefore returned a 400.

My change is to firstly look to see if the request has specified a Content-Type header and, if so, look up the corresponding format from it.  Failing that it falls back to the original behaviour of JacksonJsonParsing.bindCommand.

Thanks,
Duncan
