### PR TITLE
Fixes request format qvalue parsing (#406)

### DIFF
--- a/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
@@ -79,7 +79,13 @@ class ApiFormatsSpec extends MutableScalatraSpec {
           body must_== "html"
         }
       }
-    }
 
+      "(#406) when there are multiple formats with malformed priority the parser should ignore the broken priority " in {
+        get("/hello", headers = Map("Accept" -> "application/json; q=, application/xml; q=, text/plain, */*")) {
+          response.getContentType must startWith("text/plain")
+          body must_== "txt"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Ignores invalid qvalues sent in the `Accept` field. In addition to fixing the index exception @alexki noted in #406, qvalues outside the 0..1 range specified in the HTTP RFC are now ignored as well.
