### PR TITLE
Need a way to configure includeContextPath and includeServletPath for baseUrl

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -1,7 +1,6 @@
 package org.scalatra
 package swagger
 
-import java.util
 import java.util.{Date => JDate}
 import org.json4s._
 import org.joda.time._
@@ -24,13 +23,13 @@ trait SwaggerEngine[T <: SwaggerApi[_]] {
   def authorizations = _authorizations
   def addAuthorization(auth: AuthorizationType) { _authorizations ::= auth }
 
-
-  private val _properties = new util.HashMap[String, Any]().asScala
-  _properties += ("baseUrl.includeContextPath" -> true)
-  _properties += ("baseUrl.includeServletPath" -> false)
-  def properties = _properties
-
   def docs = _docs.values
+
+  /**
+   * Configurations used by UrlGenerator when creating baseUrl.
+   */
+  def baseUrlIncludeContextPath = true
+  def baseUrlIncludeServletPath = false
 
   /**
    * Returns the documentation for the given path.

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -15,6 +15,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
   protected implicit def jsonFormats: Formats
   protected def docToJson(doc: ApiType): JValue
 
+
   implicit override def string2RouteMatcher(path: String) = new RailsRouteMatcher(path)
 
   /**
@@ -56,7 +57,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
 
   protected def renderDoc(doc: ApiType): JValue = {
     val json = docToJson(doc) merge
-      ("basePath" -> fullUrl("/", includeContextPath = swagger.properties("baseUrl.includeContextPath").asInstanceOf[Boolean], includeServletPath = swagger.properties("baseUrl.includeServletPath").asInstanceOf[Boolean])) ~
+      ("basePath" -> fullUrl("/", includeContextPath = swagger.baseUrlIncludeContextPath, includeServletPath = swagger.baseUrlIncludeServletPath)) ~
       ("swaggerVersion" -> swagger.swaggerVersion) ~
       ("apiVersion" -> swagger.apiVersion)
     val consumes = dontAddOnEmpty("consumes", doc.consumes)_


### PR DESCRIPTION
The first iteration of these properties is for setting baseUrl paramters. First two properties are baseUrl.includeContextPath (default true) and baseUrl.includeServletPath (default false). Those properties are used when calling fullUrl which uses the UrlGenerator to fetch the baseUrl of the swagger doc.

To set properties from scalatra, configure the bootstrap file as follows: 

```
class ScalatraBootstrap extends LifeCycle {
    implicit val swagger = new Swagger
    override def init(context: ServletContext) {
        context.initParameters("swagger.api.basepath") = "http:/mydomain"
        // This will set one of the new properties in the SwaggerEngine
        swagger.properties("baseUrl.includeContextPath") = false
        /* attach the resource listing */
        context mount (new ResourcesApp, "/api-docs/*")
        /* attach controllers */
        context mount (new MyController(), "/my", "my")
    }
}
```
