### PR TITLE
Bump to Scalaz 7.1.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -386,7 +386,7 @@ object ScalatraBuild extends Build {
       case sv if sv startsWith "2.8."   => "1.5"
       case "2.9.0-1"                    => "1.8.2"
       case sv if sv startsWith "2.9."   => "1.12.4.1"
-      case _                            => "2.3.12"
+      case _                            => "2.4.2"
     }
 
   }


### PR DESCRIPTION
Code still compiles however there are issues with tests not running, not sure if its just on my end, someone will need to confirm

Also think this is somewhat a priority, since Scalaz 7.1.0 fixes some critical errors that came in Scala 2.11.x
