### PR TITLE
Patch for #416

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/RedisScalatraBroadcaster.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/RedisScalatraBroadcaster.scala
@@ -45,8 +45,8 @@ final class RedisScalatraBroadcaster()(implicit wireFormat: WireFormat, protecte
       val newMsg = filter(embeddedMsg)
 
       if (newMsg != null) {
-        val selectedResources = _resources.asScala map (_.client) filter clientFilter
-        val selectedSet = selectedResources.map(_.resource).toSet.asJava
+        val selectedResources = _resources.asScala filter clientFilter
+        val selectedSet = selectedResources.toSet.asJava
         push(new Entry(newMsg, selectedSet, new BroadcasterFuture[Any](newMsg), embeddedMsg))
       }
     } catch {
@@ -56,4 +56,3 @@ final class RedisScalatraBroadcaster()(implicit wireFormat: WireFormat, protecte
 }
 
 class Message(val msg: String, val clientFilter: ClientFilter)
-

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraBroadcaster.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/ScalatraBroadcaster.scala
@@ -18,9 +18,9 @@ trait ScalatraBroadcaster extends Broadcaster {
 
   def broadcast[T <: OutboundMessage](msg: T, clientFilter: ClientFilter)
                                      (implicit executionContext: ExecutionContext): Future[T] = {
-    val selectedResources = _resources.asScala map (_.client) filter clientFilter
+    val selectedResources = _resources.asScala filter clientFilter
     logger.trace("Sending %s to %s".format(msg, selectedResources.map(_.uuid)))
-    broadcast(_wireFormat.render(msg), selectedResources.map(_.resource).toSet.asJava).map(_ => msg)
+    broadcast(_wireFormat.render(msg), selectedResources.toSet.asJava).map(_ => msg)
   }
 
 }

--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/package.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/package.scala
@@ -11,20 +11,20 @@ package object atmosphere {
 
   type AtmoReceive = PartialFunction[InboundMessage, Unit]
 
-  abstract class ClientFilter(val uuid: String) extends Function[AtmosphereClient, Boolean]
+  abstract class ClientFilter(val uuid: String) extends Function[AtmosphereResource, Boolean]
 
   class Everyone extends ClientFilter(null) {
-    def apply(v1: AtmosphereClient): Boolean = true
+    def apply(v1: AtmosphereResource): Boolean = true
     override def toString(): String = "Everyone"
   }
 
   class OnlySelf(uuid: String) extends ClientFilter(uuid) {
-    def apply(v1: AtmosphereClient): Boolean = v1.uuid == uuid
+    def apply(v1: AtmosphereResource): Boolean = v1.uuid == uuid
     override def toString(): String = "OnlySelf"
   }
 
   class SkipSelf(uuid: String) extends ClientFilter(uuid) {
-    def apply(v1: AtmosphereClient): Boolean = v1.uuid != uuid
+    def apply(v1: AtmosphereResource): Boolean = v1.uuid != uuid
     override def toString(): String = "Others"
   }
 


### PR DESCRIPTION
Hi! I have fixed the bug #416 

At original code,
HttpSession object (included in AtmosphereResource) is converted to AtmosphereClient.
And, as he mentioned, this conversion caused a bug.

But we do not need this conversion,
because AtmosphereResource object already contains UUID (which clientFilter uses).

Thanks,
PSI.
