### PR TITLE
Bump sbt from 0.13.2 to 0.13.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.6

--- a/project/build.scala
+++ b/project/build.scala
@@ -13,11 +13,11 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{binaryIssueFilters, previousArti
 object ScalatraBuild extends Build {
   import Dependencies._
 
-  lazy val scalatraSettings = Defaults.defaultSettings ++ 
+  lazy val scalatraSettings =
     mimaDefaultSettings ++
     ls.Plugin.lsSettings ++ Seq(
     organization := "org.scalatra",
-    crossScalaVersions := Seq("2.11.1", "2.10.4"),
+    crossScalaVersions := Seq("2.11.3", "2.10.4"),
     scalaVersion <<= (crossScalaVersions) { versions => versions.head },
     scalacOptions ++= Seq("-target:jvm-1.7", "-unchecked", "-deprecation", "-Yinline-warnings", "-Xcheckinit", "-encoding", "utf8", "-feature"),
     scalacOptions ++= Seq("-language:higherKinds", "-language:postfixOps", "-language:implicitConversions", "-language:reflectiveCalls", "-language:existentials"),
@@ -31,7 +31,7 @@ object ScalatraBuild extends Build {
     (LsKeys.tags in LsKeys.lsync) := Seq("web", "sinatra", "scalatra", "akka"),
     (LsKeys.docsUrl in LsKeys.lsync) := Some(new URL("http://www.scalatra.org/guides/")),
     previousArtifact <<= (name, scalaVersion) { (name, sv) =>
-      val cross = CrossVersion.crossName(name, CrossVersion.binaryScalaVersion(sv))
+      val cross = name + "_" + CrossVersion.binaryScalaVersion(sv)
       Some("org.scalatra" % cross % "2.2.2")
     }
   ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings ++ mavenCentralFrouFrou

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,20 +1,22 @@
-scalacOptions ++= Seq("-unchecked", "-deprecation")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 resolvers ++= Seq(
-  "less is" at "http://repo.lessis.me",
+  "less is" at "http://repo.lessis.me", // TODO remove
   "coda" at "http://repo.codahale.com"
 )
 
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.4")
+addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5")
 
+// TODO Unused for 2.3.0. Should we remove this?
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+


### PR DESCRIPTION
I bumped sbt version to 0.13.6 (latest stable version) and fixed all the deprecation warnings. 
- Since I've not figured out how to use `project/Unidoc.scala`, I haven't checked it works as expected although I just fixed warnings
- I guess ls-sbt is unused now (just add TODO comments)
