### PR TITLE
Made the traits extend the new -Like scalatest traits.

### DIFF
--- a/scalatest/src/main/scala/org/scalatra/test/scalatest/scalatest.scala
+++ b/scalatest/src/main/scala/org/scalatra/test/scalatest/scalatest.scala
@@ -33,27 +33,27 @@ trait ScalatraTestNGSuite extends TestNGSuite with ScalatraSuite
 /**
  * Convenience trait to add Scalatra test support to FeatureSpec.
  */
-trait ScalatraFeatureSpec extends FeatureSpec with ScalatraSuite
+trait ScalatraFeatureSpec extends FeatureSpecLike with ScalatraSuite
 
 /**
  * Convenience trait to add Scalatra test support to Spec.
  */
-trait ScalatraSpec extends FunSpec with ScalatraSuite
+trait ScalatraSpec extends FunSpecLike with ScalatraSuite
 
 /**
  * Convenience trait to add Scalatra test support to FlatSpec.
  */
-trait ScalatraFlatSpec extends FlatSpec with ScalatraSuite
+trait ScalatraFlatSpec extends FlatSpecLike with ScalatraSuite
 
 /**
  * Convenience trait to add Scalatra test support to FreeSpec.
  */
-trait ScalatraFreeSpec extends FreeSpec with ScalatraSuite
+trait ScalatraFreeSpec extends FreeSpecLike with ScalatraSuite
 
 /**
  * Convenience trait to add Scalatra test support to WordSpec.
  */
-trait ScalatraWordSpec extends WordSpec with ScalatraSuite
+trait ScalatraWordSpec extends WordSpecLike with ScalatraSuite
 
 /**
  * Convenience trait to add Scalatra test support to FunSuite.


### PR DESCRIPTION
Following the migration guide to ScalaTest 2.x (http://www.scalatest.org/user_guide/migrating_to_20#fragileBaseClassProblem), to continue to have trait behavior it is necessary to extend their -Like counterparts rather than the original names (e.g., FlatSpec should now be FlatSpecLike).