### PR TITLE
ScalatraServlet as a trait instead of an abstract class

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -41,7 +41,7 @@ object ScalatraServlet {
 
 /**
  * An implementation of the Scalatra DSL in a servlet.  This is the recommended
- * base class for most Scalatra applications.  Use a servlet if:
+ * base trait for most Scalatra applications.  Use a servlet if:
  *
  * $ - your Scalatra routes run in a subcontext of your web application.
  * $ - you want Scalatra to have complete control of unmatched requests.
@@ -51,7 +51,7 @@ object ScalatraServlet {
  *
  * @see ScalatraFilter
  */
-abstract class ScalatraServlet
+trait ScalatraServlet
     extends HttpServlet
     with ServletBase
     with Initializable {


### PR DESCRIPTION
Currently `org.scalatra.ScalatraServlet` is an abstract class. However, I believe there is no reason that `ScalatraServlet` can be a trait because `ScalatraServlet` doesn't have a constructor.

Existing Servlet integration libraries (especially ones written in Java) provide base __classes__ to be extended. It will be smooth to use them if `ScalatraServlet` is a trait. Fortunately, we can change it to a trait without breaking backward compatibility.