### PR TITLE
Scala 2.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
   - 2.10.4
-  - 2.11.4
+  - 2.11.5
 sudo: false
 script: ./sbt ++$TRAVIS_SCALA_VERSION test
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -16,7 +16,7 @@ object ScalatraBuild extends Build {
   lazy val scalatraSettings =
     mimaDefaultSettings ++ Seq(
     organization := "org.scalatra",
-    crossScalaVersions := Seq("2.11.4", "2.10.4"),
+    crossScalaVersions := Seq("2.11.5", "2.10.4"),
     scalaVersion <<= (crossScalaVersions) { versions => versions.head },
     scalacOptions ++= Seq("-target:jvm-1.7", "-unchecked", "-deprecation", "-Yinline-warnings", "-Xcheckinit", "-encoding", "utf8", "-feature"),
     scalacOptions ++= Seq("-language:higherKinds", "-language:postfixOps", "-language:implicitConversions", "-language:reflectiveCalls", "-language:existentials"),


### PR DESCRIPTION
Scala 2.11.5 was published to Maven central repos a few days ago. Official release announcement will be made soon.

http://search.maven.org/#artifactdetails%7Corg.scala-lang%7Cscala-library%7C2.11.5%7Cjar
