### PR TITLE
set-cookie should include version number

### DIFF
--- a/core/src/main/scala/org/scalatra/CookieSupport.scala
+++ b/core/src/main/scala/org/scalatra/CookieSupport.scala
@@ -54,6 +54,9 @@ case class Cookie(name: String, value: String)(implicit cookieOptions: CookieOpt
     if (pth.nonBlank) {
       sb append "; Path=" append (if (!pth.startsWith("/")) "/" + pth else pth)
     }
+    if (cookieOptions.version > 0) {
+      sb append ("; Version=") append cookieOptions.version
+    }
     if (cookieOptions.comment.nonBlank) {
       sb append ("; Comment=") append cookieOptions.comment
     }


### PR DESCRIPTION
If version is set as greater than 0, we should include it in "Set-Cookie" header.