### PR TITLE
Fix duplicated multiParams when multipart/form-data requests

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
+++ b/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
@@ -117,11 +117,7 @@ trait FileUploadSupport extends ServletBase with HasMultipartConfig {
                 item.getFieldName, item +: params.fileParams.getOrElse(item.getFieldName, List[FileItem]())
               )), params.formParams)
             } else {
-              BodyParams(params.fileParams, params.formParams + (
-                (item.getFieldName, fileItemToString(item) ::
-                  params.formParams.getOrElse(item.getFieldName, List[String]())
-                )
-              ))
+              BodyParams(params.fileParams, params.formParams)
             }
         }
 
@@ -291,3 +287,4 @@ object Util {
   }
 
 }
+


### PR DESCRIPTION
`multiParams` looks duplicated when they came from `multipart/form-data` requests. 

 Here is a minimum example to show this issue.  https://github.com/seratch/scalatra-fileupload-bug The example app is built with [Skinny Framework](http://skinny-framework.org/) which is a thin wrapper of Scalatra. Although it's pretty simple, let me explain how the code works. First, `GET http://localhost:8080/` request returns [this HTML page](https://github.com/seratch/scalatra-fileupload-bug/blob/master/src/main/webapp/WEB-INF/views/root/index.html.ssp).  Submitting from the form will make a `multipart/form-data` request toward `POST /`. [This route definition](https://github.com/seratch/scalatra-fileupload-bug/blob/master/src/main/scala/controller/Controllers.scala#L15) accepts the `POST /` request and call [`RootController#index`](https://github.com/seratch/scalatra-fileupload-bug/blob/master/src/main/scala/controller/RootController.scala#L8-L11).

The issue is  the `datas` param looks duplicated when they came from `multipart/form-data` requests.
https://github.com/seratch/scalatra-fileupload-bug/blob/master/src/main/webapp/WEB-INF/views/root/index.html.ssp#L7-L9

When submitting above form, `multiParams` looks duplicated [here](https://github.com/seratch/scalatra-fileupload-bug/blob/master/src/main/scala/controller/RootController.scala#L9) as follows.

```
Map(datas -> WrappedArray(abc, def, 123, abc, def, 123))
```

Of course, expected output is:

```
Map(datas -> WrappedArray(abc, def, 123))
```

I just fixed the duplicated params by this pull request and all the test cases passed. But I'm afraid I may miss something. Any thought? 
If there is no problem, I'd like to merge this change before 2.4.0 final release. (If some people hope so, we should backport this fix to 2.3.x).


