### PR TITLE
Fix an XXE vulnerability related to scala.xml.XML library (2.3.x)

### DIFF
--- a/json/src/test/scala/org/scalatra/json/JsonRequestBodySpec.scala
+++ b/json/src/test/scala/org/scalatra/json/JsonRequestBodySpec.scala
@@ -42,6 +42,18 @@ class NativeJsonRequestBodySpec extends MutableScalatraSpec {
       }
     }
 
+    "parse the xml body which attempts XXE attacks" in {
+      // see also: http://blog.goodstuff.im/lift_xxe_vulnerability
+      val rbody = """<?xml version="1.0"?>
+<!DOCTYPE str [
+<!ENTITY pass SYSTEM "/etc/passwd">
+]>
+<req><name>&pass;</name></req>"""
+      post("/json", headers = Map("Accept" -> "application/xml", "Content-Type" -> "application/xml"), body = rbody) {
+        status must_== 200
+        body must_== ""
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Lift framework announced an XXE vulnerability related to scala.xml.XML library. See the following article:
http://blog.goodstuff.im/lift_xxe_vulnerability

The vulnerability also exists in Scalatra's json module. I'd like to merge this pull request and release 2.3.1 as soon as possible. Thanks in advance.