### PR TITLE
Bump json4s 3.2.11 to 3.3.0.RC1

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -358,7 +358,7 @@ object ScalatraBuild extends Build {
     private val atmosphereCompatVersion = "2.0.1"
     private val httpcomponentsVersion   = "4.3.6"
     private val jettyVersion            = "9.2.10.v20150310"
-    private val json4sVersion           = "3.2.11"
+    private val json4sVersion           = "3.3.0.RC1"
     private val scalateVersion          = "1.7.1"
     private val scalatestVersion        = "2.2.4"
     private val specs2Version           = "2.4.17"

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
@@ -39,7 +39,12 @@ object SwaggerSerializers {
       new GrantTypeSerializer)
   }
   trait SwaggerFormats extends DefaultFormats {
+
     private[this] val self = this
+
+    // since 2.4.0: anyway set as false by default
+    val strict: Boolean = false
+
     def withAuthorizationTypeSerializer(serializer: Serializer[AuthorizationType]): SwaggerFormats = new SwaggerFormats {
       override val customSerializers: List[Serializer[_]] = serializer :: SwaggerFormats.serializers
     }

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/ScalaSigReader.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/ScalaSigReader.scala
@@ -1,7 +1,7 @@
 package org.scalatra.swagger.reflect
 
 import scala.annotation.tailrec
-import scala.tools.scalap.scalax.rules.scalasig._
+import org.json4s.scalap.scalasig._
 
 private[reflect] object ScalaSigReader {
   def readConstructor(argName: String, clazz: Class[_], typeArgIndex: Int, argNames: List[String]): Class[_] = {


### PR DESCRIPTION
json4s 3.3.0.RC1 is out. https://github.com/json4s/json4s/releases/tag/3.3.0.RC1

This pull request bumps json4s version 3.2 to 3.3.0.RC1.
