### PR TITLE
Bump dependencies

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -300,23 +300,24 @@ object ScalatraBuild extends Build {
   )
 
   object Dependencies {
-    lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "1.0.3"
-    lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "1.0.3"
+    lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "1.0.4"
+    lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "1.0.4"
     lazy val akkaActor                =  "com.typesafe.akka"       %% "akka-actor"                 % akkaVersion
     lazy val akkaTestkit              =  "com.typesafe.akka"       %% "akka-testkit"               % akkaVersion
+    // TODO: 2.3 has incompatible API changes
     lazy val atmosphereRuntime        =  "org.atmosphere"          %  "atmosphere-runtime"         % "2.2.6"
-    lazy val atmosphereJQuery         =  "org.atmosphere.client"   %  "jquery"                     % "2.2.8" artifacts(Artifact("jquery", "war", "war"))
-    lazy val atmosphereClient         =  "org.atmosphere"          %  "wasync"                     % "1.4.3"
-    lazy val atmosphereRedis          =  "org.atmosphere"          %  "atmosphere-redis"           % "2.2.1"
+    lazy val atmosphereJQuery         =  "org.atmosphere.client"   %  "jquery"                     % "2.2.11" artifacts(Artifact("jquery", "war", "war"))
+    lazy val atmosphereClient         =  "org.atmosphere"          %  "wasync"                     % "2.1.2"
+    lazy val atmosphereRedis          =  "org.atmosphere"          %  "atmosphere-redis"           % "2.3.0"
     lazy val atmosphereCompatJbossweb =  "org.atmosphere"          %  "atmosphere-compat-jbossweb" % atmosphereCompatVersion
     lazy val atmosphereCompatTomcat   =  "org.atmosphere"          %  "atmosphere-compat-tomcat"   % atmosphereCompatVersion
     lazy val atmosphereCompatTomcat7  =  "org.atmosphere"          %  "atmosphere-compat-tomcat7"  % atmosphereCompatVersion
     lazy val base64                   =  "net.iharder"             %  "base64"                     % "2.3.8"
     lazy val commonsFileupload        =  "commons-fileupload"      %  "commons-fileupload"         % "1.3.1"
     lazy val commonsIo                =  "commons-io"              %  "commons-io"                 % "2.4"
-    lazy val commonsLang3             =  "org.apache.commons"      %  "commons-lang3"              % "3.3.2"
+    lazy val commonsLang3             =  "org.apache.commons"      %  "commons-lang3"              % "3.4"
     lazy val grizzledSlf4j            =  "org.clapper"             %% "grizzled-slf4j"             % grizzledSlf4jVersion
-    lazy val guice                    =  "com.google.inject"       %  "guice"                      % "3.0"
+    lazy val guice                    =  "com.google.inject"       %  "guice"                      % "4.0"
     lazy val httpclient               =  "org.apache.httpcomponents" % "httpclient"                % httpcomponentsVersion
     lazy val httpmime                 =  "org.apache.httpcomponents" % "httpmime"                  % httpcomponentsVersion
     lazy val jettyServer              =  "org.eclipse.jetty"       %  "jetty-server"               % jettyVersion
@@ -332,35 +333,37 @@ object ScalatraBuild extends Build {
     lazy val json4sNative             =  "org.json4s"              %% "json4s-native"              % json4sVersion
     lazy val junit                    =  "junit"                   %  "junit"                      % "4.11"
     lazy val jUniversalChardet        =  "com.googlecode.juniversalchardet" % "juniversalchardet"  % "1.0.3"
-    lazy val logbackClassic           =  "ch.qos.logback"          %  "logback-classic"            % "1.1.2"
+    lazy val logbackClassic           =  "ch.qos.logback"          %  "logback-classic"            % "1.1.3"
     lazy val mimeUtil                 =  "eu.medsea.mimeutil"      %  "mime-util"                  % "2.1.3" exclude("org.slf4j", "slf4j-log4j12") exclude("log4j", "log4j")
     lazy val mockitoAll               =  "org.mockito"             %  "mockito-all"                % "1.10.19"
     lazy val rl                       =  "org.scalatra.rl"         %% "rl"                         % "0.4.10"
     lazy val scalajCollection         =  "org.scalaj"              %% "scalaj-collection"          % "1.2"
     lazy val scalate                  =  "org.scalatra.scalate"    %% "scalate-core"               % scalateVersion
     lazy val scalatest                =  "org.scalatest"           %% "scalatest"                  % scalatestVersion
-    lazy val scalaz                   =  "org.scalaz"              %% "scalaz-core"                % "7.1.1"
+    lazy val scalaz                   =  "org.scalaz"              %% "scalaz-core"                % "7.1.2"
     lazy val servletApi               =  "javax.servlet"           %  "javax.servlet-api"          % "3.1.0"
     lazy val springWeb                =  "org.springframework"     %  "spring-web"                 % "4.1.5.RELEASE"
-    lazy val slf4jApi                 =  "org.slf4j"               %  "slf4j-api"                  % "1.7.10"
-    lazy val slf4jSimple              =  "org.slf4j"               %  "slf4j-simple"               % "1.7.10"
+    lazy val slf4jApi                 =  "org.slf4j"               %  "slf4j-api"                  % "1.7.12"
+    lazy val slf4jSimple              =  "org.slf4j"               %  "slf4j-simple"               % "1.7.12"
     lazy val specs2                   =  "org.specs2"              %% "specs2"                     % specs2Version
     lazy val testJettyServlet         =  "org.eclipse.jetty"       %  "test-jetty-servlet"         % jettyVersion
-    lazy val testng                   =  "org.testng"              %  "testng"                     % "6.8.21"
+    lazy val testng                   =  "org.testng"              %  "testng"                     % "6.9.4"
+    // TODO:  3.5 has incompatible API changes
     lazy val metricsScala             =  "nl.grons"                %% "metrics-scala"              % "3.3.0_a2.3"
-    lazy val metricsServlets          =  "io.dropwizard.metrics"   %  "metrics-servlets"           % "3.1.1"
-    lazy val metricsServlet           =  "io.dropwizard.metrics"   %  "metrics-servlet"            % "3.1.1"
+    lazy val metricsServlets          =  "io.dropwizard.metrics"   %  "metrics-servlets"           % "3.1.2"
+    lazy val metricsServlet           =  "io.dropwizard.metrics"   %  "metrics-servlet"            % "3.1.2"
     lazy val googleGuava              =  "com.google.guava"        % "guava"                       % "18.0"
-    lazy val googleFindBugs           = "com.google.code.findbugs" % "jsr305"                      % "1.3.9"
+    lazy val googleFindBugs           = "com.google.code.findbugs" % "jsr305"                      % "3.0.0"
 
-    private val akkaVersion             = "2.3.9"
+    private val akkaVersion             = "2.3.11"
     private val grizzledSlf4jVersion    = "1.0.2"
     private val atmosphereCompatVersion = "2.0.1"
-    private val httpcomponentsVersion   = "4.3.6"
+    private val httpcomponentsVersion   = "4.4.1"
     private val jettyVersion            = "9.2.10.v20150310"
-    private val json4sVersion           = "3.3.0.RC1"
+    private val json4sVersion           = "3.3.0.RC2"
     private val scalateVersion          = "1.7.1"
-    private val scalatestVersion        = "2.2.4"
+    private val scalatestVersion        = "2.2.5"
+    // TODO: 3.3 has incompatible API changes
     private val specs2Version           = "2.4.17"
   }
 


### PR DESCRIPTION
json4s, scala-xml, scala-parser-combinators, google-guice, httpclient, scalaz-core, slf4j, akka, scalatest and so on.

I didn't fix some incompatible API changes in atmosphere, metrics and specs2 modules. Is there anyone interested in fixing them?