### PR TITLE
Updated specs2 to 3.6.+

### DIFF
--- a/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
+++ b/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
@@ -11,7 +11,7 @@ import org.json4s.JsonDSL._
 import org.json4s.{ DefaultFormats, Formats, _ }
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.test.specs2.MutableScalatraSpec
-import org.specs2.specification.{ Fragments, Step }
+import org.specs2.specification._
 
 import scala.concurrent.duration._
 
@@ -152,5 +152,8 @@ class AtmosphereSpec extends MutableScalatraSpec {
     system.awaitTermination(Duration(1, TimeUnit.MINUTES))
   }
 
-  override def map(fs: => Fragments): Fragments = super.map(fs) ^ Step(stopSystem)
+  override def afterAll = {
+    super.afterAll
+    stopSystem
+  }
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -25,6 +25,7 @@ object ScalatraBuild extends Build {
     resolvers ++= Seq(
       Opts.resolver.sonatypeSnapshots,
       Opts.resolver.sonatypeReleases,
+      "bintray/non" at "http://dl.bintray.com/non/maven",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
       "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases" // specs2 2.4.3 or higher requires this
     ),
@@ -181,18 +182,17 @@ object ScalatraBuild extends Build {
     id = "scalatra-test",
     base = file("test"),
     settings = scalatraSettings ++ Seq(
-      libraryDependencies <++= scalaVersion(sv => Seq(
+      libraryDependencies ++= Seq(
         grizzledSlf4j,
         jettyWebapp,
         servletApi,
         mockitoAll,
         commonsLang3,
-        specs2 % "test",
         httpclient,
         httpmime,
         jodaTime % "provided",
         jodaConvert % "provided"
-      )),
+      ) ++ specs2.map(_ % "test"),
       description := "The abstract Scalatra test framework"
     )
   ) dependsOn(scalatraCommon % "compile;test->test;provided->provided")
@@ -210,7 +210,7 @@ object ScalatraBuild extends Build {
     id = "scalatra-specs2",
     base = file("specs2"),
     settings = scalatraSettings ++ Seq(
-      libraryDependencies += specs2,
+      libraryDependencies ++= specs2,
       description := "Specs2 support for the Scalatra test framework"
     )
   ) dependsOn(scalatraTest % "compile;test->test;provided->provided")
@@ -345,7 +345,11 @@ object ScalatraBuild extends Build {
     lazy val springWeb                =  "org.springframework"     %  "spring-web"                 % "4.1.5.RELEASE"
     lazy val slf4jApi                 =  "org.slf4j"               %  "slf4j-api"                  % "1.7.12"
     lazy val slf4jSimple              =  "org.slf4j"               %  "slf4j-simple"               % "1.7.12"
-    lazy val specs2                   =  "org.specs2"              %% "specs2"                     % specs2Version
+    lazy val specs2                   =  Seq(
+                                         "org.specs2"              %% "specs2-core",
+                                         "org.specs2"              %% "specs2-mock",
+                                         "org.specs2"              %% "specs2-matcher-extra"
+                                                                                    ).map(_        % specs2Version)
     lazy val testJettyServlet         =  "org.eclipse.jetty"       %  "test-jetty-servlet"         % jettyVersion
     lazy val testng                   =  "org.testng"              %  "testng"                     % "6.9.4"
     lazy val metricsScala             =  "nl.grons"                %% "metrics-scala"              % "3.5.1"
@@ -362,8 +366,7 @@ object ScalatraBuild extends Build {
     private val json4sVersion           = "3.3.0.RC2"
     private val scalateVersion          = "1.7.1"
     private val scalatestVersion        = "2.2.5"
-    // TODO: 3.3 has incompatible API changes
-    private val specs2Version           = "2.4.17"
+    private val specs2Version           = "3.6-20150519234533-6476871"
   }
 
   lazy val manifestSetting = packageOptions <+= (name, version, organization) map {

--- a/scalate/src/test/scala/org/scalatra/scalate/ScalateFuturesSupportSpec.scala
+++ b/scalate/src/test/scala/org/scalatra/scalate/ScalateFuturesSupportSpec.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.{ ExecutorService, Executors, ThreadFactory }
 import org.fusesource.scalate.layout.DefaultLayoutStrategy
 import org.scalatra._
 import org.scalatra.test.specs2.MutableScalatraSpec
-import org.specs2.specification.{ Fragments, Step }
+import org.specs2.specification._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -163,7 +163,10 @@ class ScalateFuturesSupportSpec extends MutableScalatraSpec {
   val pool = DaemonThreadFactory.newPool()
   addServlet(new ScalateFuturesSupportServlet(pool), "/*")
 
-  override def map(fs: => Fragments): Fragments = super.map(fs) ^ Step(pool.shutdown())
+  override def afterAll = {
+    super.afterAll
+    pool.shutdown()
+  }
 
   def e1 = get("/barf") {
     status must_== 500

--- a/specs2/src/main/scala/org/scalatra/test/specs2/BaseScalatraSpec.scala
+++ b/specs2/src/main/scala/org/scalatra/test/specs2/BaseScalatraSpec.scala
@@ -2,14 +2,14 @@ package org.scalatra
 package test
 package specs2
 
-import org.specs2.mutable.FragmentsBuilder
-import org.specs2.specification.{ Fragments, SpecificationStructure, Step }
+import org.specs2.specification.BeforeAfterAll
 
 /**
  * A base specification structure that starts the tester before the
  * specification and stops it afterward.  Clients probably want to extend
  * ScalatraSpec or MutableScalatraSpec.
  */
-trait BaseScalatraSpec extends SpecificationStructure with FragmentsBuilder with ScalatraTests {
-  override def map(fs: => Fragments) = Step(start()) ^ super.map(fs) ^ Step(stop())
+trait BaseScalatraSpec extends BeforeAfterAll with ScalatraTests {
+  def beforeAll = start()
+  def afterAll = stop()
 }

--- a/swagger/src/test/scala/org/scalatra/swagger/SubPathSwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SubPathSwaggerSpec.scala
@@ -7,7 +7,7 @@ import org.scalatra.test.specs2.ScalatraSpec
 import org.specs2.matcher.JsonMatchers
 
 class SubPathSwaggerSpec extends ScalatraSpec with JsonMatchers {
-  val is = s2"""
+  def is = s2"""
   Swagger integration should
     list resources $listResources
     list hacker operations $listHackerOperations

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerApiLookupSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerApiLookupSpec.scala
@@ -7,7 +7,7 @@ import org.scalatra.test.specs2.ScalatraSpec
 import org.specs2.matcher.JsonMatchers
 
 class SwaggerApiLookupSpec extends ScalatraSpec with JsonMatchers {
-  val is = s2"""
+  def is = s2"""
   Swagger integration should
     list resources using Servlet path to generate listing path $listResources
     host the API listing of a Servlet without a custom name $listFooOperations

--- a/test/src/test/scala/org/scalatra/test/EmbeddedJettyContainerSpec.scala
+++ b/test/src/test/scala/org/scalatra/test/EmbeddedJettyContainerSpec.scala
@@ -3,13 +3,15 @@ package org.scalatra.test
 import javax.servlet.http._
 
 import org.specs2.mutable._
-import org.specs2.specification.{ Fragments, Step }
+import org.specs2.specification.BeforeAfterAll
 
-class EmbeddedJettyContainerSpec extends Specification
+class EmbeddedJettyContainerSpec extends SpecificationLike
     with EmbeddedJettyContainer
-    with HttpComponentsClient {
-  override def map(fs: => Fragments) =
-    Step(start()) ^ super.map(fs) ^ Step(stop())
+    with HttpComponentsClient
+    with BeforeAfterAll {
+
+  def beforeAll = start()
+  def afterAll = stop()
 
   addServlet(new HttpServlet {
     override def doGet(req: HttpServletRequest, res: HttpServletResponse) = {
@@ -25,7 +27,7 @@ class EmbeddedJettyContainerSpec extends Specification
     }
 
     "have a default servlet" in {
-      get("/") { header("X-Has-Default-Servlet") must_== "true" }
+      get("/") { response.header("X-Has-Default-Servlet") must_== "true" }
     }
   }
 }

--- a/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
+++ b/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
@@ -4,7 +4,7 @@ import java.io.{ InputStream, OutputStream }
 import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
 
 import org.specs2.mutable.Specification
-import org.specs2.specification.{ Fragments, Step }
+import org.specs2.specification.BeforeAfterAll
 
 import scala.annotation.tailrec
 import scala.collection.JavaConversions._
@@ -12,8 +12,11 @@ import scala.collection.JavaConversions._
 class HttpComponentsClientSpec
     extends Specification
     with HttpComponentsClient
-    with EmbeddedJettyContainer {
-  override def map(fs: => Fragments) = Step(start()) ^ super.map(fs) ^ Step(stop())
+    with EmbeddedJettyContainer
+    with BeforeAfterAll {
+
+  def beforeAll = start()
+  def afterAll = stop()
 
   addServlet(new HttpServlet {
     override def service(req: HttpServletRequest, resp: HttpServletResponse) {


### PR DESCRIPTION
I am using a temporary (but stable) version of specs2 to get around [this issue](https://issues.scala-lang.org/browse/SI-9321?jql=text%20~%20%22%5C%22declaring%20an%20override%5C%22%22), but this PR should fix #506. 