### PR TITLE
s/fail/failure

### DIFF
--- a/commands/src/main/scala/org/scalatra/validation/Validators.scala
+++ b/commands/src/main/scala/org/scalatra/validation/Validators.scala
@@ -23,7 +23,7 @@ object Validators {
       extends Validator[TValue] {
     def validate[TResult >: TValue <: TValue](value: TResult): FieldValidation[TResult] = {
       if (isValid(value)) value.success
-      else ValidationError(messageFormat.format(fieldName.underscore.humanize), FieldName(fieldName), ValidationFail).fail[TResult]
+      else ValidationError(messageFormat.format(fieldName.underscore.humanize), FieldName(fieldName), ValidationFail).failure[TResult]
     }
   }
 


### PR DESCRIPTION
https://github.com/scalaz/scalaz/blob/v7.1.2/core/src/main/scala/scalaz/syntax/ValidationOps.scala#L11-L12

`ValidationOps#fail` is deprecated