### PR TITLE
Fix #518 [2.4.0.RC2] StableResult is not always accessible via macros except org.scalatra package

### DIFF
--- a/core/src/main/scala/org/scalatra/StableResult.scala
+++ b/core/src/main/scala/org/scalatra/StableResult.scala
@@ -5,7 +5,7 @@ import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
 
 // Provides a stable request/response to an action.
 // Each action is wrapped in a StableResult during compilation.
-protected abstract class StableResult(
+abstract class StableResult(
   implicit override val scalatraContext: ScalatraContext)
     extends ScalatraContext {
 

--- a/core/src/test/scala/example/StableResultVisibilityTest.scala
+++ b/core/src/test/scala/example/StableResultVisibilityTest.scala
@@ -1,0 +1,33 @@
+package example
+
+import org.scalatra._
+import org.scalatra.test.scalatest.ScalatraFunSuite
+
+/*
+> scalatra/test
+
+[error] /xxx/scalatra/core/src/test/scala/example/StableResultVisibilityTest.scala:9: class StableResult in package scalatra cannot be accessed in package org.scalatra
+[error]  Access to protected class StableResult not permitted because
+[error]  enclosing object SimpleServlet in class StableResultVisibilityTest is not a subclass of
+[error]  package scalatra in package org where target is defined
+[error]     get("/") {
+[error]              ^
+[error] one error found
+[error] (scalatra/test:compileIncremental) Compilation failed
+ */
+class StableResultVisibilityTest extends ScalatraFunSuite {
+
+  class SimpleServlet extends ScalatraServlet {
+    get("/") {
+      "ok"
+    }
+  }
+  addServlet(new SimpleServlet, "/*")
+
+  test("Accessing StableResult via macros should be allowed") {
+    get("/") {
+      status should equal(200)
+      body should equal("ok")
+    }
+  }
+}


### PR DESCRIPTION
See #518