### PR TITLE
StableResult macro fixes

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -180,7 +180,7 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
     route.copy(metadata = route.metadata + ('Atmosphere -> 'Atmosphere))
   }
 
-  def atmosphere(transformers: RouteTransformer*)(block: => AtmosphereClient) = {
+  def atmosphere(transformers: RouteTransformer*)(block: => AtmosphereClient): Unit = {
     val newTransformers = transformers :+ Atmosphere
     get(newTransformers: _*)(block)
     post(newTransformers: _*) { () }

--- a/core/src/main/scala-2.10/org/scalatra/MacrosCompat.scala
+++ b/core/src/main/scala-2.10/org/scalatra/MacrosCompat.scala
@@ -1,17 +1,17 @@
 package org.scalatra
 
-object MacrosCompat {
+trait MacrosCompat extends Internal210 {
 
   type Context = scala.reflect.macros.Context
 
-  def freshName[C <: Context](c: C)(name: String): String = c.fresh(name)
+  def freshName(name: String): String = c.fresh(name)
 
-  def typeName[C <: Context](c: C)(name: String): c.universe.TypeName  = c.universe.newTypeName(name)
+  def typeName(name: String): c.universe.TypeName  = c.universe.newTypeName(name)
 
-  def termName[C <: Context](c: C)(name: String): c.universe.TermName = c.universe.newTermName(name)
+  def termName(name: String): c.universe.TermName = c.universe.newTermName(name)
 
-  def typecheck[C <: Context](c: C)(tree: c.universe.Tree): c.universe.Tree = c.typeCheck(tree)
+  def typecheck(tree: c.universe.Tree): c.universe.Tree = c.typeCheck(tree)
 
-  def untypecheck[C <: Context](c: C)(tree: c.universe.Tree): c.universe.Tree = c.resetLocalAttrs(tree)
+  def untypecheck(tree: c.universe.Tree): c.universe.Tree = c.resetLocalAttrs(tree)
 
 }

--- a/core/src/main/scala-2.11/org/scalatra/MacrosCompat.scala
+++ b/core/src/main/scala-2.11/org/scalatra/MacrosCompat.scala
@@ -1,17 +1,17 @@
 package org.scalatra
 
-object MacrosCompat {
+trait MacrosCompat extends Internal210 {
 
   type Context = scala.reflect.macros.blackbox.Context
 
-  def freshName[C <: Context](c: C)(name: String): String = c.freshName(name)
+  def freshName(name: String): String = c.freshName(name)
 
-  def typeName[C <: Context](c: C)(name: String): c.universe.TypeName  = c.universe.TypeName(name)
+  def typeName(name: String): c.universe.TypeName  = c.universe.TypeName(name)
 
-  def termName[C <: Context](c: C)(name: String): c.universe.TermName = c.universe.TermName(name)
+  def termName(name: String): c.universe.TermName = c.universe.TermName(name)
 
-  def typecheck[C <: Context](c: C)(tree: c.universe.Tree): c.universe.Tree = c.typecheck(tree)
+  def typecheck(tree: c.universe.Tree): c.universe.Tree = c.typecheck(tree)
 
-  def untypecheck[C <: Context](c: C)(tree: c.universe.Tree): c.universe.Tree = c.untypecheck(tree)
+  def untypecheck(tree: c.universe.Tree): c.universe.Tree = c.untypecheck(tree)
 
 }

--- a/core/src/main/scala/org/scalatra/CoreDslMacros.scala
+++ b/core/src/main/scala/org/scalatra/CoreDslMacros.scala
@@ -53,7 +53,7 @@ object CoreDslMacros {
       // add to new lexical scope
       val rescopedExpr =
         q"""
-            class $clsName extends org.scalatra.StableResult {
+            class $clsName extends _root_.org.scalatra.StableResult {
               val is = {
                 $untypedExpr
               }
@@ -75,21 +75,22 @@ object CoreDslMacros {
     import c.universe._
 
     val rescopedAction = rescopeExpression[c.type](c)(action)
-    c.Expr[Route](q"""addRoute($method, Seq(..$transformers), $rescopedAction)""")
+    c.Expr[Route](q"""addRoute($method, _root_.scala.collection.immutable.Seq(..$transformers), $rescopedAction)""")
   }
 
   def beforeImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
     import c.universe._
 
     val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""routes.appendBeforeFilter(Route(Seq(..$transformers), () => $rescopedAction))""")
+    c.Expr[Unit](q"""routes.appendBeforeFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => $rescopedAction))""")
+
   }
 
   def afterImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
     import c.universe._
 
     val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""routes.appendAfterFilter(Route(Seq(..$transformers), () => $rescopedAction))""")
+    c.Expr[Unit](q"""routes.appendAfterFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => $rescopedAction))""")
   }
 
   def getImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
@@ -131,7 +132,7 @@ object CoreDslMacros {
     import c.universe._
 
     val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""addStatusRoute(Range($code, $code+1), $rescopedAction)""")
+    c.Expr[Unit](q"""addStatusRoute(scala.collection.immutable.Range($code, $code+1), $rescopedAction)""")
   }
 
   def notFoundImpl(c: Context)(block: c.Expr[Any]): c.Expr[Unit] = {
@@ -151,7 +152,7 @@ object CoreDslMacros {
 
     val tree =
       q"""
-          doMethodNotAllowed = (methods: Set[HttpMethod]) => ${rescopeExpression[c.type](c)(block)}(methods)
+          doMethodNotAllowed = (methods: _root_.scala.collection.immutable.Set[_root_.org.scalatra.HttpMethod]) => ${rescopeExpression[c.type](c)(block)}(methods)
         """
 
     c.Expr[Unit](tree)
@@ -163,17 +164,17 @@ object CoreDslMacros {
     val tree =
       q"""
           errorHandler = {
-           new PartialFunction[Throwable, Any]() {
+           new _root_.scala.PartialFunction[_root_.java.lang.Throwable, _root_.scala.Any]() {
 
              def handler = {
                ${rescopeExpression[c.type](c)(handler)}
              }
 
-             override def apply(v1: Throwable): Any = {
+             override def apply(v1: _root_.java.lang.Throwable): _root_.scala.Any = {
                handler.apply(v1)
              }
 
-             override def isDefinedAt(x: Throwable): Boolean = {
+             override def isDefinedAt(x: _root_.java.lang.Throwable): _root_.scala.Boolean = {
                handler.isDefinedAt(x)
              }
 

--- a/core/src/main/scala/org/scalatra/CoreDslMacros.scala
+++ b/core/src/main/scala/org/scalatra/CoreDslMacros.scala
@@ -3,190 +3,164 @@ package org.scalatra
 import scala.language.experimental.macros
 
 import MacrosCompat.{ Context, freshName, typeName, termName, typecheck, untypecheck }
+import Compat210._
 
 /**
  * Macro implementation which generates Scalatra core DSL APIs.
  */
 object CoreDslMacros {
 
-  /**
-   * Re-scopes the expression.
-   *
-   * - takes an Expr[Any], wraps it in a StableResult.
-   * - replaces all references to request/response to use the stable values from StableResult (instead of the ThreadLocal)
-   * - returns StableResult.is
-   */
-  def rescopeExpression[C <: Context](c: C)(expr: c.Expr[Any]): c.Expr[Any] = {
+  import scala.reflect.macros._
+  // import blackbox.Context
+
+  class CoreDslMacros[C <: Context](val c: C) extends Internal210 {
+
     import c.universe._
-    import c.internal._
 
-    val typeIsNothing = expr.actualType =:= implicitly[TypeTag[Nothing]].tpe
+    /**
+     * Re-scopes the expression.
+     *
+     * - takes an Expr[Any], wraps it in a StableResult.
+     * - replaces all references to request/response to use the stable values from StableResult (instead of the ThreadLocal)
+     * - returns StableResult.is
+     */
+    def rescopeExpression(expr: c.Expr[Any]): c.Expr[Any] = {
+      import c.universe._
+      import internal._
 
-    if (!typeIsNothing && expr.actualType <:< implicitly[TypeTag[AsyncResult]].tpe) {
-      // return an AsyncResult (for backward compatibility, AsyncResult is deprecated in 2.4)
+      val typeIsNothing = expr.actualType =:= implicitly[TypeTag[Nothing]].tpe
 
-      c.Expr[Any](q"""${splicer[c.type](c)(expr.tree)}""")
+      if (!typeIsNothing && expr.actualType <:< implicitly[TypeTag[AsyncResult]].tpe) {
+        // return an AsyncResult (for backward compatibility, AsyncResult is deprecated in 2.4)
 
-    } else if (!typeIsNothing && expr.actualType <:< implicitly[TypeTag[StableResult]].tpe) {
-      // return a StableResult.is
+        c.Expr[Any](q"""${splicer(expr.tree)}""")
 
-      c.Expr[Any](q"""${splicer[c.type](c)(expr.tree)}.is""")
+      } else if (!typeIsNothing && expr.actualType <:< implicitly[TypeTag[StableResult]].tpe) {
+        // return a StableResult.is
 
-    } else {
-      // in all other cases wrap the action in a StableResult to provide a stable lexical scope and return the res.is
+        c.Expr[Any](q"""${splicer(expr.tree)}.is""")
 
-      val clsName = typeName[c.type](c)(freshName(c)("cls"))
-      val resName = termName[c.type](c)(freshName(c)("res"))
+      } else {
+        // in all other cases wrap the action in a StableResult to provide a stable lexical scope and return the res.is
 
-      // add to new lexical scope
-      val rescopedTree =
-        q"""
+        val clsName = typeName[c.type](c)(freshName[c.type](c)("cls"))
+        val resName = termName[c.type](c)(freshName[c.type](c)("res"))
+
+        // add to new lexical scope
+        val rescopedTree =
+          q"""
             class $clsName extends _root_.org.scalatra.StableResult {
               val is = {
-                ${splicer[c.type](c)(expr.tree)}
+                ${splicer(expr.tree)}
               }
             }
             val $resName = new $clsName()
             $resName.is
          """
 
-      // typecheck the three, creates symbols (class, valdefs)
-      val rescopedTreeTyped = c.typecheck(rescopedTree)
+        // typecheck the three, creates symbols (class, valdefs)
+        val rescopedTreeTyped = typecheck[c.type](c)(rescopedTree)
 
-      // use stable request/response values from the new lexical scope
-      val transformedTreeTyped = c.internal.typingTransform(rescopedTreeTyped)((tree, api) => tree match {
-        case q"$a.this.request" => api.typecheck(Select(This(clsName), TermName("request")))
-        case q"$a.this.response" => api.typecheck(Select(This(clsName), TermName("response")))
-        case _ => api.default(tree)
-      })
+        // use stable request/response values from the new lexical scope
+        val transformedTreeTyped = c.internal.typingTransform(rescopedTreeTyped)((tree, api) => tree match {
+          case q"$a.this.request" => api.typecheck(Select(This(clsName), termName[c.type](c)("request")))
+          case q"$a.this.response" => api.typecheck(Select(This(clsName), termName[c.type](c)("response")))
+          case _ => api.default(tree)
+        })
 
-      c.Expr[Unit](transformedTreeTyped)
+        c.Expr[Unit](transformedTreeTyped)
+
+      }
 
     }
 
-  }
-
-  // inspired by https://gist.github.com/retronym/10640845#file-macro2-scala
-  // check out the gist for a detailed explanation of the technique
-  private def splicer[C <: Context](c: C)(tree: c.Tree): c.Tree = {
-    import c.universe._, c.internal._, decorators._
-    tree.updateAttachment(OrigOwnerAttachment(enclosingOwner))
-    q"_root_.org.scalatra.CoreDslMacros.Splicer.changeOwner($tree)"
-  }
-
-  case class OrigOwnerAttachment(sym: Any)
-  object Splicer {
-    def impl(c: Context)(tree: c.Tree): c.Tree = {
-      import c.universe._, c.internal._, decorators._
-      val origOwner = tree.attachments.get[OrigOwnerAttachment].map(_.sym).get.asInstanceOf[Symbol]
-      c.internal.changeOwner(tree, origOwner, c.internal.enclosingOwner)
+    def addRouteGen(method: c.Expr[HttpMethod], transformers: Seq[c.Expr[RouteTransformer]], action: c.Expr[Any]): c.Expr[Route] = {
+      val rescopedAction = rescopeExpression(action)
+      c.Expr[Route](q"""addRoute($method, _root_.scala.collection.immutable.Seq(..$transformers), $rescopedAction)""")
     }
-    def changeOwner[A](tree: A): A = macro impl
-  }
 
-  def addRouteGen[C <: Context](c: C)(method: c.Expr[HttpMethod], transformers: Seq[c.Expr[RouteTransformer]], action: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
+    def beforeImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
+      val rescopedAction = rescopeExpression(block)
+      c.Expr[Unit](q"""routes.appendBeforeFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => ${splicer(rescopedAction.tree)}))""")
 
-    val rescopedAction = rescopeExpression[c.type](c)(action)
-    c.Expr[Route](q"""addRoute($method, _root_.scala.collection.immutable.Seq(..$transformers), $rescopedAction)""")
-  }
+    }
 
-  def beforeImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
-    import c.universe._
+    def afterImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
+      val rescopedAction = rescopeExpression(block)
+      c.Expr[Unit](q"""routes.appendAfterFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => ${splicer(rescopedAction.tree)}))""")
+    }
 
-    val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""routes.appendBeforeFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => ${splicer[c.type](c)(rescopedAction.tree)}))""")
+    def getImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Get), transformers, action)
+    }
 
-  }
+    def postImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Post), transformers, action)
+    }
 
-  def afterImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
-    import c.universe._
+    def putImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Put), transformers, action)
+    }
 
-    val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""routes.appendAfterFilter(_root_.org.scalatra.Route(Seq(..$transformers), () => ${splicer[c.type](c)(rescopedAction.tree)}))""")
-  }
+    def deleteImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Delete), transformers, action)
+    }
 
-  def getImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Get), transformers, action)
-  }
+    def optionsImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Options), transformers, action)
+    }
 
-  def postImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Post), transformers, action)
-  }
+    def headImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Head), transformers, action)
+    }
 
-  def putImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Put), transformers, action)
-  }
+    def patchImpl(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(c.universe.reify(Patch), transformers, action)
+    }
 
-  def deleteImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Delete), transformers, action)
-  }
+    def trapImpl(codes: c.Expr[Range])(block: c.Expr[Any]): c.Expr[Unit] = {
+      val rescopedAction = rescopeExpression(block)
+      c.Expr[Unit](q"""addStatusRoute($codes, $rescopedAction)""")
+    }
 
-  def optionsImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Options), transformers, action)
-  }
+    def trapCodeImpl(code: c.Expr[Int])(block: c.Expr[Any]): c.Expr[Unit] = {
+      val rescopedAction = rescopeExpression(block)
+      c.Expr[Unit](q"""addStatusRoute(scala.collection.immutable.Range($code, $code+1), $rescopedAction)""")
+    }
 
-  def headImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Head), transformers, action)
-  }
+    def notFoundImpl(block: c.Expr[Any]): c.Expr[Unit] = {
+      val rescopedBlock = rescopeExpression(block)
 
-  def patchImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
-    addRouteGen[c.type](c)(c.universe.reify(Patch), transformers, action)
-  }
-
-  def trapImpl(c: Context)(codes: c.Expr[Range])(block: c.Expr[Any]): c.Expr[Unit] = {
-    import c.universe._
-
-    val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""addStatusRoute($codes, $rescopedAction)""")
-  }
-
-  def trapCodeImpl(c: Context)(code: c.Expr[Int])(block: c.Expr[Any]): c.Expr[Unit] = {
-    import c.universe._
-
-    val rescopedAction = rescopeExpression[c.type](c)(block)
-    c.Expr[Unit](q"""addStatusRoute(scala.collection.immutable.Range($code, $code+1), $rescopedAction)""")
-  }
-
-  def notFoundImpl(c: Context)(block: c.Expr[Any]): c.Expr[Unit] = {
-    import c.universe._
-
-    val rescopedBlock = rescopeExpression[c.type](c)(block)
-
-    val tree = q"""
+      val tree = q"""
       doNotFound = {
-        () => ${splicer[c.type](c)(rescopedBlock.tree)}
+        () => ${splicer(rescopedBlock.tree)}
       }
     """
 
-    c.Expr[Unit](tree)
-  }
+      c.Expr[Unit](tree)
+    }
 
-  def methodNotAllowedImpl(c: Context)(block: c.Expr[Set[HttpMethod] => Any]): c.Expr[Unit] = {
-    import c.universe._
+    def methodNotAllowedImpl(block: c.Expr[Set[HttpMethod] => Any]): c.Expr[Unit] = {
+      val rescopedBlock = rescopeExpression(block)
 
-    val rescopedBlock = rescopeExpression[c.type](c)(block)
-
-    val tree =
-      q"""
-          doMethodNotAllowed = (methods: _root_.scala.collection.immutable.Set[_root_.org.scalatra.HttpMethod]) => ${splicer[c.type](c)(rescopedBlock.tree)}(methods)
+      val tree =
+        q"""
+          doMethodNotAllowed = (methods: _root_.scala.collection.immutable.Set[_root_.org.scalatra.HttpMethod]) => ${splicer(rescopedBlock.tree)}(methods)
         """
 
-    c.Expr[Unit](tree)
-  }
+      c.Expr[Unit](tree)
+    }
 
-  def errorImpl(c: Context)(handler: c.Expr[ErrorHandler]): c.Expr[Unit] = {
-    import c.universe._
+    def errorImpl(handler: c.Expr[ErrorHandler]): c.Expr[Unit] = {
+      val rescopedHandler = rescopeExpression(handler)
 
-    val rescopedHandler = rescopeExpression[c.type](c)(handler)
-
-    val tree =
-      q"""
+      val tree =
+        q"""
           errorHandler = {
            new _root_.scala.PartialFunction[_root_.java.lang.Throwable, _root_.scala.Any]() {
 
              def handler = {
-               ${splicer[c.type](c)(rescopedHandler.tree)}
+               ${splicer(rescopedHandler.tree)}
              }
 
              override def apply(v1: _root_.java.lang.Throwable): _root_.scala.Any = {
@@ -201,43 +175,155 @@ object CoreDslMacros {
          } orElse errorHandler
         """
 
-    c.Expr[Unit](tree)
+      c.Expr[Unit](tree)
+    }
+
+    // TODO check
+
+    def makeAsynchronously(block: c.Expr[Any]): c.Expr[Any] = {
+      val block1 = untypecheck[c.type](c)(block.tree.duplicate)
+      c.Expr[Any](typecheck[c.type](c)(q"""asynchronously($block1)()"""))
+    }
+
+    def asyncGetImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Get), transformers, makeAsynchronously(block))
+    }
+
+    def asyncPostImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Post), transformers, makeAsynchronously(block))
+    }
+
+    def asyncPutImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Put), transformers, makeAsynchronously(block))
+    }
+
+    def asyncDeleteImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Delete), transformers, makeAsynchronously(block))
+    }
+
+    def asyncOptionsImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Options), transformers, makeAsynchronously(block))
+    }
+
+    def asyncPatchImpl(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
+      addRouteGen(reify(Patch), transformers, makeAsynchronously(block))
+    }
+
+    // inspired by https://gist.github.com/retronym/10640845#file-macro2-scala
+    // check out the gist for a detailed explanation of the technique
+    private def splicer(tree: c.Tree): c.Tree = {
+      import internal._, decorators._
+      tree.updateAttachment(macroutil.OrigOwnerAttachment(c.internal.enclosingOwner))
+      q"_root_.org.scalatra.macroutil.Splicer.changeOwner($tree)"
+    }
+
   }
 
-  def makeAsynchronously[C <: Context](c: C)(block: c.Expr[Any]): c.Expr[Any] = {
-    import c.universe._
-    val block1 = untypecheck[c.type](c)(block.tree.duplicate)
-    c.Expr[Any](typecheck[c.type](c)(q"""asynchronously($block1)()"""))
+  def beforeImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).beforeImpl(transformers: _*)(block)
+  }
+
+  def afterImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).afterImpl(transformers: _*)(block)
+  }
+
+  def getImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).getImpl(transformers: _*)(action)
+  }
+
+  def postImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).postImpl(transformers: _*)(action)
+  }
+
+  def putImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).putImpl(transformers: _*)(action)
+  }
+
+  def deleteImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).deleteImpl(transformers: _*)(action)
+  }
+
+  def optionsImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).optionsImpl(transformers: _*)(action)
+  }
+
+  def headImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).headImpl(transformers: _*)(action)
+  }
+
+  def patchImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(action: c.Expr[Any]): c.Expr[Route] = {
+    new CoreDslMacros[c.type](c).patchImpl(transformers: _*)(action)
+  }
+
+  def trapImpl(c: Context)(codes: c.Expr[Range])(block: c.Expr[Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).trapImpl(codes)(block)
+  }
+
+  def trapCodeImpl(c: Context)(code: c.Expr[Int])(block: c.Expr[Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).trapCodeImpl(code)(block)
+  }
+
+  def notFoundImpl(c: Context)(block: c.Expr[Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).notFoundImpl(block)
+  }
+
+  def methodNotAllowedImpl(c: Context)(block: c.Expr[Set[HttpMethod] => Any]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).methodNotAllowedImpl(block)
+  }
+
+  def errorImpl(c: Context)(handler: c.Expr[ErrorHandler]): c.Expr[Unit] = {
+    new CoreDslMacros[c.type](c).errorImpl(handler)
   }
 
   def asyncGetImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Get), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncGetImpl(transformers: _*)(block)
   }
 
   def asyncPostImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Post), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncPostImpl(transformers: _*)(block)
   }
 
   def asyncPutImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Put), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncPutImpl(transformers: _*)(block)
   }
 
   def asyncDeleteImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Delete), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncDeleteImpl(transformers: _*)(block)
   }
 
   def asyncOptionsImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Options), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncOptionsImpl(transformers: _*)(block)
   }
 
   def asyncPatchImpl(c: Context)(transformers: c.Expr[RouteTransformer]*)(block: c.Expr[Any]): c.Expr[Route] = {
-    import c.universe._
-    addRouteGen[c.type](c)(reify(Patch), transformers, makeAsynchronously[c.type](c)(block))
+    new CoreDslMacros[c.type](c).asyncPatchImpl(transformers: _*)(block)
+  }
+
+}
+
+package macroutil {
+
+  case class OrigOwnerAttachment(sym: Any)
+
+  object Splicer {
+
+    import scala.reflect.macros._
+    import blackbox.Context
+
+    def impl[A](c: Context)(expr: c.Expr[A]): c.Expr[A] = {
+      val helper = new Splicer[c.type](c)
+      c.Expr[A](helper.changeOwner(expr.tree))
+    }
+
+    class Splicer[C <: Context](val c: C) extends Internal210 {
+      def changeOwner(tree: c.Tree): c.Tree = {
+        import c.universe._, internal._, decorators._
+        val origOwner = tree.attachments.get[OrigOwnerAttachment].map(_.sym).get.asInstanceOf[Symbol]
+        c.internal.changeOwner(tree, origOwner, c.internal.enclosingOwner)
+      }
+    }
+
+    def changeOwner[A](expr: A): A = macro impl[A]
   }
 
 }

--- a/core/src/main/scala/org/scalatra/CoreDslMacros.scala
+++ b/core/src/main/scala/org/scalatra/CoreDslMacros.scala
@@ -51,7 +51,7 @@ object CoreDslMacros {
          """
 
       // typecheck the three, creates symbols (class, valdefs)
-      val rescopedTreeTyped = c.typecheck(rescopedTree)  // this is not the owner
+      val rescopedTreeTyped = c.typecheck(rescopedTree)
 
       // use stable request/response values from the new lexical scope
       val transformedTreeTyped = c.internal.typingTransform(rescopedTreeTyped)((tree, api) => tree match {

--- a/core/src/main/scala/org/scalatra/Internal210.scala
+++ b/core/src/main/scala/org/scalatra/Internal210.scala
@@ -1,0 +1,100 @@
+package org.scalatra
+
+// defines stubs for stuff that's missing in Scala 2.10
+object Compat210 {
+  object blackbox { // scala.reflect.macros.blackbox package
+    type Context = scala.reflect.macros.Context
+  }
+  object internal // Context.internal object
+  object decorators // Context.decorators object
+  object contexts // scala.reflect.macros.contexts package
+}
+import Compat210._
+
+// unifies scala.reflect.macros.runtime.Context (Scala 2.10)
+// and scala.reflect.macros.contexts.Context (Scala 2.11)
+object Power {
+  import scala.reflect.macros._
+  object DummyScope {
+    import runtime._
+    import contexts._
+    type Result = Context
+  }
+  type PowerContext = DummyScope.Result
+}
+import Power._
+
+// a cake slice that can be mixed into improvised macro bundles
+// to transparently bring new Scala 2.11 features to Scala 2.10
+trait Internal210 { self =>
+  import scala.reflect.macros._
+  import blackbox.Context
+
+  val c: Context
+  import c.universe._
+
+  // enrichments that backport parts of Scala 2.11's c.internal to Scala 2.10
+  // these are only going to be picked up if we compile against Scala 2.10
+  implicit class RichContext(val c: self.c.type) {
+    object internal {
+      def enclosingOwner: Symbol = {
+        val powerContext = c.asInstanceOf[PowerContext]
+        powerContext.callsiteTyper.context.owner.asInstanceOf[Symbol]
+      }
+      def changeOwner(tree: Tree, oldOwner: Symbol, newOwner: Symbol): Tree = {
+        val powerContext = c.asInstanceOf[PowerContext]
+        val global = powerContext.universe
+        class ChangeOwnerAndModuleClassTraverser(oldOwner: global.Symbol, newOwner: global.Symbol) extends global.ChangeOwnerTraverser(oldOwner, newOwner) {
+          override def traverse(tree: global.Tree) {
+            tree match {
+              case _: global.DefTree => change(tree.symbol.moduleClass)
+              case _ =>
+            }
+            super.traverse(tree)
+          }
+        }
+        val traverser = new ChangeOwnerAndModuleClassTraverser(oldOwner.asInstanceOf[global.Symbol], newOwner.asInstanceOf[global.Symbol])
+        traverser.traverse(tree.asInstanceOf[global.Tree])
+        tree
+      }
+      def valDef(sym: Symbol, rhs: Tree): ValDef = {
+        val powerContext = c.asInstanceOf[PowerContext]
+        val global = powerContext.universe
+        global.ValDef(sym.asInstanceOf[global.Symbol], rhs.asInstanceOf[global.Tree]).asInstanceOf[ValDef]
+      }
+      trait TypingTransformApi {
+        def default(tree: Tree): Tree
+        def typecheck(tree: Tree): Tree
+      }
+      def typingTransform(tree: Tree)(transformer: (Tree, TypingTransformApi) => Tree): Tree = {
+        val powerContext = c.asInstanceOf[PowerContext]
+        val global = powerContext.universe
+        class MiniCake[G <: scala.tools.nsc.Global](val global: G) extends scala.tools.nsc.transform.TypingTransformers {
+          val callsiteTyper = powerContext.callsiteTyper.asInstanceOf[global.analyzer.Typer]
+          class HofTypingTransformer(hof: (Tree, TypingTransformApi) => Tree) extends TypingTransformer(callsiteTyper.context.unit) { self =>
+            currentOwner = callsiteTyper.context.owner
+            curTree = global.EmptyTree
+            localTyper = global.analyzer.newTyper(callsiteTyper.context.make(unit = callsiteTyper.context.unit))
+            val api = new TypingTransformApi {
+              def default(tree: Tree): Tree = superTransform(tree.asInstanceOf[global.Tree]).asInstanceOf[Tree]
+              def typecheck(tree: Tree): Tree = localTyper.typed(tree.asInstanceOf[global.Tree]).asInstanceOf[Tree]
+            }
+            def superTransform(tree: global.Tree) = super.transform(tree)
+            override def transform(tree: global.Tree): global.Tree = hof(tree.asInstanceOf[Tree], api).asInstanceOf[global.Tree]
+          }
+        }
+        val miniCake = new MiniCake[global.type](global)
+        new miniCake.HofTypingTransformer(transformer).transform(tree.asInstanceOf[global.Tree]).asInstanceOf[Tree]
+      }
+    }
+  }
+
+  // we can't use Symbol.setInfo in Scala 2.10 (doesn't exist yet) or Symbol.setTypeSignature in Scala 2.11 (has been removed)
+  // therefore we need to settle on some sort of a middle ground
+  implicit class RichSymbol(val sym: self.c.universe.Symbol) {
+    def setInfoCompat(info: Type): Symbol = {
+      import compat._
+      sym.setTypeSignature(info)
+    }
+  }
+}

--- a/core/src/test/scala/example/StableResultVisibilityTest.scala
+++ b/core/src/test/scala/example/StableResultVisibilityTest.scala
@@ -1,6 +1,7 @@
 package example
 
-import org.scalatra._
+// Don't import org.scalatra._ here to detect macros errors
+import org.scalatra.ScalatraServlet
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
 /*
@@ -18,8 +19,36 @@ import org.scalatra.test.scalatest.ScalatraFunSuite
 class StableResultVisibilityTest extends ScalatraFunSuite {
 
   class SimpleServlet extends ScalatraServlet {
+
+    // #525 [2.4.0.RC2-1] "not found: value Route"
+    before() {
+    }
+    before("/") {
+    }
+
     get("/") {
       "ok"
+    }
+    trap(100) {
+    }
+
+    after() {
+    }
+    after("/") {
+    }
+
+    case class FooException(msg: String) extends Exception
+
+    error {
+      // case scala.util.control.NonFatal(e) =>
+      case FooException(msg) =>
+    }
+
+    notFound {
+    }
+
+    methodNotAllowed {
+      case methods =>
     }
   }
   addServlet(new SimpleServlet, "/*")

--- a/core/src/test/scala/example/StableResultVisibilityTest.scala
+++ b/core/src/test/scala/example/StableResultVisibilityTest.scala
@@ -40,8 +40,7 @@ class StableResultVisibilityTest extends ScalatraFunSuite {
     case class FooException(msg: String) extends Exception
 
     error {
-      // case scala.util.control.NonFatal(e) =>
-      case FooException(msg) =>
+       case scala.util.control.NonFatal(e) =>
     }
 
     notFound {

--- a/core/src/test/scala/example/StableResultVisibilityTest.scala
+++ b/core/src/test/scala/example/StableResultVisibilityTest.scala
@@ -40,7 +40,7 @@ class StableResultVisibilityTest extends ScalatraFunSuite {
     case class FooException(msg: String) extends Exception
 
     error {
-       case scala.util.control.NonFatal(e) =>
+      case scala.util.control.NonFatal(e) =>
     }
 
     notFound {

--- a/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
@@ -45,7 +45,7 @@ class AkkaSupportServlet extends ScalatraServlet with FutureSupport {
 
   get("/async-oh-noes") {
     new AsyncResult {
-      val is = Future {
+      override val is = Future {
         Thread.sleep(100) // To get the container to give up the request
         Ok(body = s"${request.getContextPath}")
       }
@@ -56,7 +56,7 @@ class AkkaSupportServlet extends ScalatraServlet with FutureSupport {
     request.setAttribute("sessionId", params("mockSessionId"))
     val handlingReq = request
     new AsyncResult {
-      val is = Future {
+      override val is = Future {
         Thread.sleep(200)
         Ok(body = request.getAttribute("sessionId"))
       }(futureEC)

--- a/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/AkkaSupportSpec.scala
@@ -45,7 +45,7 @@ class AkkaSupportServlet extends ScalatraServlet with FutureSupport {
 
   get("/async-oh-noes") {
     new AsyncResult {
-      override val is = Future {
+      val is = Future {
         Thread.sleep(100) // To get the container to give up the request
         Ok(body = s"${request.getContextPath}")
       }
@@ -56,7 +56,7 @@ class AkkaSupportServlet extends ScalatraServlet with FutureSupport {
     request.setAttribute("sessionId", params("mockSessionId"))
     val handlingReq = request
     new AsyncResult {
-      override val is = Future {
+      val is = Future {
         Thread.sleep(200)
         Ok(body = request.getAttribute("sessionId"))
       }(futureEC)

--- a/core/src/test/scala/org/scalatra/StableResultSpec.scala
+++ b/core/src/test/scala/org/scalatra/StableResultSpec.scala
@@ -10,6 +10,22 @@ class StableResultServlet extends ScalatraServlet with FutureSupport {
 
   override implicit val executor = scala.concurrent.ExecutionContext.global
 
+  class X {
+    val routes: Int = 100
+
+    get("/foo") {
+
+    }
+  }
+
+  val x = new X
+
+  case class Route(x: Int)
+
+  before("/*") {
+    contentType = "text/html"
+  }
+
   get("/ok") {
     Ok(123)
   }

--- a/core/src/test/scala/org/scalatra/StableResultSpec.scala
+++ b/core/src/test/scala/org/scalatra/StableResultSpec.scala
@@ -64,48 +64,48 @@ class StableResultServlet extends ScalatraServlet with FutureSupport {
   //   res$macro$6.is
   // })
 
-  // make sure that ScalatraBase methods are invoked
-  class X {
-    val routes: Int = 100
-    val addRoute: Int = 100
-    val addStatusRoute: Int = 100
-    val doNotFound: Int = 100
-    val doMethodNotAllowed: Int = 100
-    val errorHandler: Int = 100
-    val asynchronously: Int = 100
-
-    before("/*") {
-      contentType = "text/html"
-    }
-
-    after("/*") {
-      contentType = "text/html"
-    }
-
-    get("/foo") {
-
-    }
-
-    asyncGet("/foo") {
-
-    }
-
-    error {
-      case e =>
-    }
-
-    methodNotAllowed {
-      case methods =>
-    }
-
-    trap(100) {
-
-    }
-
-    notFound {
-
-    }
-  }
+//  // make sure that ScalatraBase methods are invoked
+//  class X {
+//    val routes: Int = 100
+//    val addRoute: Int = 100
+//    val addStatusRoute: Int = 100
+//    val doNotFound: Int = 100
+//    val doMethodNotAllowed: Int = 100
+//    val errorHandler: Int = 100
+//    val asynchronously: Int = 100
+//
+//    before("/*") {
+//      contentType = "text/html"
+//    }
+//
+//    after("/*") {
+//      contentType = "text/html"
+//    }
+//
+//    get("/foo") {
+//
+//    }
+//
+//    asyncGet("/foo") {
+//
+//    }
+//
+//    error {
+//      case e =>
+//    }
+//
+//    methodNotAllowed {
+//      case methods =>
+//    }
+//
+//    trap(100) {
+//
+//    }
+//
+//    notFound {
+//
+//    }
+//  }
 
   case class Route(x: Int)
 

--- a/core/src/test/scala/org/scalatra/StableResultSpec.scala
+++ b/core/src/test/scala/org/scalatra/StableResultSpec.scala
@@ -64,51 +64,50 @@ class StableResultServlet extends ScalatraServlet with FutureSupport {
   //   res$macro$6.is
   // })
 
-//  // make sure that ScalatraBase methods are invoked
-//  class X {
-//    val routes: Int = 100
-//    val addRoute: Int = 100
-//    val addStatusRoute: Int = 100
-//    val doNotFound: Int = 100
-//    val doMethodNotAllowed: Int = 100
-//    val errorHandler: Int = 100
-//    val asynchronously: Int = 100
-//
-//    before("/*") {
-//      contentType = "text/html"
-//    }
-//
-//    after("/*") {
-//      contentType = "text/html"
-//    }
-//
-//    get("/foo") {
-//
-//    }
-//
-//    asyncGet("/foo") {
-//
-//    }
-//
-//    error {
-//      case e =>
-//    }
-//
-//    methodNotAllowed {
-//      case methods =>
-//    }
-//
-//    trap(100) {
-//
-//    }
-//
-//    notFound {
-//
-//    }
-//  }
+  //  // make sure that ScalatraBase methods are invoked
+  //  class X {
+  //    val routes: Int = 100
+  //    val addRoute: Int = 100
+  //    val addStatusRoute: Int = 100
+  //    val doNotFound: Int = 100
+  //    val doMethodNotAllowed: Int = 100
+  //    val errorHandler: Int = 100
+  //    val asynchronously: Int = 100
+  //
+  //    before("/*") {
+  //      contentType = "text/html"
+  //    }
+  //
+  //    after("/*") {
+  //      contentType = "text/html"
+  //    }
+  //
+  //    get("/foo") {
+  //
+  //    }
+  //
+  //    asyncGet("/foo") {
+  //
+  //    }
+  //
+  //    error {
+  //      case e =>
+  //    }
+  //
+  //    methodNotAllowed {
+  //      case methods =>
+  //    }
+  //
+  //    trap(100) {
+  //
+  //    }
+  //
+  //    notFound {
+  //
+  //    }
+  //  }
 
   case class Route(x: Int)
-
 
   // here are some more issues which will be addressed in the future:
   //

--- a/core/src/test/scala/org/scalatra/StableResultSpec.scala
+++ b/core/src/test/scala/org/scalatra/StableResultSpec.scala
@@ -36,6 +36,32 @@ class StableResultServlet extends ScalatraServlet with FutureSupport {
   //    res$macro$4.is
   //  }
 
+  notFound {
+    halt(404, <h1>Not found.</h1>)
+  }
+
+  // rewritten to:
+  //
+  // doNotFound = (() => {
+  //   class cls$macro$5 extends org.scalatra.StableResult {
+  //     def <init>() = {
+  //       super.<init>();
+  //       ()
+  //     };
+  //     val is = StableResultServlet.this.halt[scala.xml.Elem](scala.this.Predef.int2Integer(404), {
+  //       {
+  //         new scala.xml.Elem(null, "h1", scala.xml.Null, scala.this.xml.TopScope, false, ({
+  //           val $buf = new scala.xml.NodeBuffer();
+  //           $buf.&+(new scala.xml.Text("Not found."));
+  //           $buf
+  //         }: _*))
+  //       }
+  //     }, StableResultServlet.this.halt$default$3[Nothing], StableResultServlet.this.halt$default$4[Nothing])(reflect.this.ManifestFactory.classType[scala.xml.Elem](classOf[scala.xml.Elem]))
+  //   };
+  //   val res$macro$6 = new cls$macro$5();
+  //   res$macro$6.is
+  // })
+
   // here are some more issues which will be addressed in the future:
   //
   //  var futureEffect = false

--- a/core/src/test/scala/org/scalatra/StableResultSpec.scala
+++ b/core/src/test/scala/org/scalatra/StableResultSpec.scala
@@ -1,7 +1,5 @@
 package org.scalatra
 
-import javax.servlet.http.HttpServletRequest
-
 import org.scalatra.test.specs2.MutableScalatraSpec
 
 import scala.concurrent.Future
@@ -9,18 +7,6 @@ import scala.concurrent.Future
 class StableResultServlet extends ScalatraServlet with FutureSupport {
 
   override implicit val executor = scala.concurrent.ExecutionContext.global
-
-  class X {
-    val routes: Int = 100
-
-    get("/foo") {
-
-    }
-  }
-
-  val x = new X
-
-  case class Route(x: Int)
 
   before("/*") {
     contentType = "text/html"
@@ -77,6 +63,52 @@ class StableResultServlet extends ScalatraServlet with FutureSupport {
   //   val res$macro$6 = new cls$macro$5();
   //   res$macro$6.is
   // })
+
+  // make sure that ScalatraBase methods are invoked
+  class X {
+    val routes: Int = 100
+    val addRoute: Int = 100
+    val addStatusRoute: Int = 100
+    val doNotFound: Int = 100
+    val doMethodNotAllowed: Int = 100
+    val errorHandler: Int = 100
+    val asynchronously: Int = 100
+
+    before("/*") {
+      contentType = "text/html"
+    }
+
+    after("/*") {
+      contentType = "text/html"
+    }
+
+    get("/foo") {
+
+    }
+
+    asyncGet("/foo") {
+
+    }
+
+    error {
+      case e =>
+    }
+
+    methodNotAllowed {
+      case methods =>
+    }
+
+    trap(100) {
+
+    }
+
+    notFound {
+
+    }
+  }
+
+  case class Route(x: Int)
+
 
   // here are some more issues which will be addressed in the future:
   //

--- a/project/build.scala
+++ b/project/build.scala
@@ -70,7 +70,9 @@ object ScalatraBuild extends Build {
     base = file("core"),
     settings = scalatraSettings ++ Seq(
       libraryDependencies <++= scalaVersion(sv => {
-        val default = Seq(servletApi % "provided;test",
+        val default = Seq(
+          servletApi % "provided;test",
+          scalaCompiler(sv) % "provided",
           reflect(sv),
           slf4jApi,
           grizzledSlf4j,
@@ -306,6 +308,7 @@ object ScalatraBuild extends Build {
     lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "1.0.4"
     lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "1.0.4"
     def reflect(sv: String)           =  "org.scala-lang"          %  "scala-reflect"              % sv
+    def scalaCompiler(sv: String)     =  "org.scala-lang"          %  "scala-compiler"             % sv
     lazy val quasiquotes              =  "org.scalamacros"         %% "quasiquotes"                % paradiseVersion
     lazy val akkaActor                =  "com.typesafe.akka"       %% "akka-actor"                 % akkaVersion
     lazy val akkaTestkit              =  "com.typesafe.akka"       %% "akka-testkit"               % akkaVersion


### PR DESCRIPTION
This patch fixes a few problems

- Handle action results of type Nothing (see below)
- Handle owner chain bug
  - use a multi-level macro approach
  - untypechecking does not work, since trees are already transformed and cant be typed later correctly (see https://gist.github.com/dozed/d49ee979dc657f5a8829, https://github.com/scalatra/scalatra/issues/527)
  - transformation needs to type the subtrees (`typingTransform`)
- Macro hygiene (see http://docs.scala-lang.org/overviews/quasiquotes/hygiene.html)
  - use fully qualified type names, e.g. `_root_.org.scalatra.Route` instead of `Route`
      - does not require imports at the callsite
      - generated code refers to correct symbols
  - invoke methods from `ScalatraBase` (**TODO**)

--------

Details for Nothing issue: Actions returning Nothing, e.g. when using halt(). Nothing conforms to all types and also to StableResult/AsyncResult. This lead to an expression of type Nothing not being wrapped in a StableResult.

Example:

```scala
notFound {
  halt(404, <h1>Not found.</h1>)
}
```


Was rewritten to:

```scala
doNotFound = (() => StableResultServlet.this.halt[scala.xml.Elem](scala.this.Predef.int2Integer(404), {
  {
    new scala.xml.Elem(null, "h1", scala.xml.Null, scala.this.xml.TopScope, false, ({
      val $buf: scala.xml.NodeBuffer = new scala.xml.NodeBuffer();
      $buf.&+(new scala.xml.Text("Not found."));
      $buf
    }: _*))
  }
}, StableResultServlet.this.halt$default$3[Nothing], StableResultServlet.this.halt$default$4[Nothing])(reflect.this.ManifestFactory.classType[scala.xml.Elem](classOf[scala.xml.Elem])))
```


It should be rewritten to:

```scala
doNotFound = (() => {
  class cls$macro$5 extends org.scalatra.StableResult {
    def <init>() = {
      super.<init>();
      ()
    };
    val is = StableResultServlet.this.halt[scala.xml.Elem](scala.this.Predef.int2Integer(404), {
      {
        new scala.xml.Elem(null, "h1", scala.xml.Null, scala.this.xml.TopScope, false, ({
          val $buf = new scala.xml.NodeBuffer();
          $buf.&+(new scala.xml.Text("Not found."));
          $buf
        }: _*))
      }
    }, StableResultServlet.this.halt$default$3[Nothing], StableResultServlet.this.halt$default$4[Nothing])(reflect.this.ManifestFactory.classType[scala.xml.Elem](classOf[scala.xml.Elem]))
  };
  val res$macro$6 = new cls$macro$5();
  res$macro$6.is
})
```
