### PR TITLE
Added request/response as implicits to DSL methods. Fixes #435.

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -94,7 +94,7 @@ trait ScalatraServlet
    * Attempts to find a static resource matching the request path.  Override
    * to return None to stop this.
    */
-  protected def serveStaticResource(): Option[Any] = {
+  protected def serveStaticResource()(implicit request: HttpServletRequest, response: HttpServletResponse): Option[Any] = {
     servletContext.resource(request) map { _ =>
       servletContext.getNamedDispatcher("default").forward(request, response)
     }
@@ -104,7 +104,7 @@ trait ScalatraServlet
    * Called by default notFound if no routes matched and no static resource
    * could be found.
    */
-  protected def resourceNotFound(): Any = {
+  protected def resourceNotFound()(implicit request: HttpServletRequest, response: HttpServletResponse): Any = {
     response.setStatus(404)
     if (isDevelopmentMode) {
       val error = "Requesting \"%s %s\" on servlet \"%s\" but only have: %s"

--- a/sbt
+++ b/sbt
@@ -115,7 +115,7 @@ declare -r script_name="${script_path##*/}"
 declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://typesafe.artifactoryonline.com/typesafe/ivy-releases"
+declare sbt_launch_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args

--- a/sbt
+++ b/sbt
@@ -195,7 +195,7 @@ download_url () {
 
   mkdir -p "${jar%/*}" && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateI18nSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateI18nSupport.scala
@@ -23,8 +23,8 @@ trait ScalateI18nSupport extends ScalateSupport with I18nSupport {
    * Added "messages" into the template context so it can be accessed like:
    * #{messages("hello")}
    */
-  override protected def createRenderContext(req: HttpServletRequest = request, resp: HttpServletResponse = response, out: PrintWriter = response.getWriter): RenderContext = {
-    val context = super.createRenderContext(req, resp, out)
+  override protected def createRenderContext(out: PrintWriter)(implicit request: HttpServletRequest, response: HttpServletResponse): RenderContext = {
+    val context = super.createRenderContext(out)
     context.attributes("messages") = messages(request)
     context
   }

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateRenderSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateRenderSupport.scala
@@ -1,6 +1,8 @@
 package org.scalatra
 package scalate
 
+import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
+
 trait ScalateRenderSupport { self: ScalatraBase with ScalateSupport =>
 
   val templateBaseDirectory = "/WEB-INF/scalate/templates"
@@ -14,7 +16,7 @@ trait ScalateRenderSupport { self: ScalatraBase with ScalateSupport =>
   lazy val oneMonth = oneWeek * 4
   lazy val oneYear = oneWeek * 52
 
-  def render(file: String, params: Map[String, Any] = Map(), responseContentType: String = "text/html", cacheMaxAge: Int = none, statusCode: Int = 200) {
+  def render(file: String, params: Map[String, Any] = Map(), responseContentType: String = "text/html", cacheMaxAge: Int = none, statusCode: Int = 200)(implicit request: HttpServletRequest, response: HttpServletResponse) {
     contentType = responseContentType
     response.setHeader("Cache-Control", "public, max-age=%d" format cacheMaxAge)
     response.setStatus(statusCode)

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
@@ -117,8 +117,8 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
    * If you return something other than a ScalatraRenderContext, you will
    * also want to redefine that binding.
    */
-  protected def createRenderContext(req: HttpServletRequest = request, resp: HttpServletResponse = response, out: PrintWriter = response.getWriter): RenderContext = {
-    new ScalatraRenderContext(this, templateEngine, out, req, resp)
+  protected def createRenderContext(out: PrintWriter)(implicit request: HttpServletRequest, response: HttpServletResponse): RenderContext = {
+    new ScalatraRenderContext(this, templateEngine, out, request, response)
   }
 
   /**
@@ -128,7 +128,7 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
    */
   @deprecated("not idiomatic Scalate; consider layoutTemplate instead", "2.0.0")
   def renderTemplate(path: String, attributes: (String, Any)*)(implicit request: HttpServletRequest, response: HttpServletResponse) =
-    createRenderContext(request, response, response.writer).render(path, Map(attributes: _*))
+    createRenderContext(response.writer).render(path, Map(attributes: _*))
 
   /**
    * Flag whether the Scalate error page is enabled.  If true, uncaught
@@ -148,17 +148,17 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
   }
 
   override protected def renderUncaughtException(e: Throwable)(implicit request: HttpServletRequest, response: HttpServletResponse) {
-    if (isScalateErrorPageEnabled) renderScalateErrorPage(request, response, e)
+    if (isScalateErrorPageEnabled) renderScalateErrorPage(e)
     else super.renderUncaughtException(e)
   }
 
   // Hack: Have to pass it the request and response, because we're outside the
   // scope of the super handler.
-  private[this] def renderScalateErrorPage(req: HttpServletRequest, resp: HttpServletResponse, e: Throwable) = {
-    resp.setStatus(500)
-    resp.setContentType("text/html")
+  private[this] def renderScalateErrorPage(e: Throwable)(implicit request: HttpServletRequest, response: HttpServletResponse) = {
+    response.setStatus(500)
+    response.setContentType("text/html")
     val errorPage = templateEngine.load("/WEB-INF/scalate/errors/500.scaml")
-    val context = createRenderContext(req, resp, resp.getWriter)
+    val context = createRenderContext(response.getWriter)
     context.setAttribute("javax.servlet.error.exception", Some(e))
     templateEngine.layout(errorPage, context)
   }
@@ -239,7 +239,7 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
     val uri = findTemplate(path, ext).getOrElse(path)
     val buffer = new StringWriter()
     val out = new PrintWriter(buffer)
-    val context = createRenderContext(request, response, out)
+    val context = createRenderContext(out)
     val attrs = templateAttributes ++ (defaultLayoutPath map (p => Map("layout" -> p) ++ Map(attributes: _*)) getOrElse Map(attributes: _*))
 
     attrs foreach {

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
@@ -66,25 +66,36 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
     super.shutdown()
   }
 
+  protected def contextKey(config: ConfigT): String = {
+
+    val ctxId = config.getServletContext().toString
+
+    val ctxKey = config.getServletContext.getContextPath match {
+      case "" => "ROOT"
+      case path => path.substring(1)
+    }
+
+    f"$ctxId/$ctxKey"
+
+  }
+  
   /**
    * Creates the templateEngine from the config.  There is little reason to
    * override this unless you have created a ServletBase extension outside
    * an HttpServlet or Filter.
    */
   protected def createTemplateEngine(config: ConfigT): TemplateEngine = {
-    val ctx = config.getServletContext.getContextPath match {
-      case "" => "ROOT"
-      case path => path.substring(1)
-    }
+    val ctxKey = contextKey(config)
+    
     config match {
       case servletConfig: ServletConfig =>
-        ScalateSupport.scalateTemplateEngine(ctx, new ServletTemplateEngine(servletConfig) with ScalatraTemplateEngine)
+        ScalateSupport.scalateTemplateEngine(ctxKey, new ServletTemplateEngine(servletConfig) with ScalatraTemplateEngine)
       case filterConfig: FilterConfig =>
-        ScalateSupport.scalateTemplateEngine(ctx, new ServletTemplateEngine(filterConfig) with ScalatraTemplateEngine)
+        ScalateSupport.scalateTemplateEngine(ctxKey, new ServletTemplateEngine(filterConfig) with ScalatraTemplateEngine)
       case _ =>
         // Don't know how to convert your Config to something that
         // ServletTemplateEngine can accept, so fall back to a TemplateEngine
-        ScalateSupport.scalateTemplateEngine(ctx, new TemplateEngine with ScalatraTemplateEngine)
+        ScalateSupport.scalateTemplateEngine(ctxKey, new TemplateEngine with ScalatraTemplateEngine)
     }
   }
 

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala
@@ -66,27 +66,25 @@ trait ScalateSupport extends org.scalatra.servlet.ServletBase {
     super.shutdown()
   }
 
-  protected def contextKey(config: ConfigT): String = {
-
-    val ctxId = config.getServletContext().toString
-
-    val ctxKey = config.getServletContext.getContextPath match {
-      case "" => "ROOT"
-      case path => path.substring(1)
-    }
-
-    f"$ctxId/$ctxKey"
-
-  }
-  
   /**
    * Creates the templateEngine from the config.  There is little reason to
    * override this unless you have created a ServletBase extension outside
    * an HttpServlet or Filter.
    */
   protected def createTemplateEngine(config: ConfigT): TemplateEngine = {
+    def contextKey(config: ConfigT): String = {
+      val ctxId = config.getServletContext.hashCode.toString
+
+      val ctxKey = config.getServletContext.getContextPath match {
+        case "" => "ROOT"
+        case path => path.substring(1)
+      }
+
+      f"$ctxId/$ctxKey"
+    }
+
     val ctxKey = contextKey(config)
-    
+
     config match {
       case servletConfig: ServletConfig =>
         ScalateSupport.scalateTemplateEngine(ctxKey, new ServletTemplateEngine(servletConfig) with ScalatraTemplateEngine)

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateUrlGeneratorSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateUrlGeneratorSupport.scala
@@ -23,8 +23,8 @@ trait ScalateUrlGeneratorSupport extends ScalateSupport {
     engine
   }
 
-  override protected def createRenderContext(req: HttpServletRequest = request, res: HttpServletResponse = response, out: PrintWriter = response.getWriter) = {
-    val context = super.createRenderContext(req, res, out)
+  override protected def createRenderContext(out: PrintWriter)(implicit request: HttpServletRequest, response: HttpServletResponse) = {
+    val context = super.createRenderContext(out)
     for ((name, route) <- this.reflectRoutes)
       context.attributes.update(name, route)
     //    context.attributes.update("urlGenerator", UrlGenerator)

--- a/scalate/src/test/resources/hello.mustache
+++ b/scalate/src/test/resources/hello.mustache
@@ -1,0 +1,1 @@
+i say hello

--- a/scalate/src/test/scala/org/scalatra/scalate/ScalateI18nSupportSpec.scala
+++ b/scalate/src/test/scala/org/scalatra/scalate/ScalateI18nSupportSpec.scala
@@ -1,0 +1,27 @@
+package org.scalatra.scalate
+
+import org.scalatra.{ FutureSupport, ScalatraServlet }
+import org.scalatra.test.specs2.MutableScalatraSpec
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class ScalateI18nSupportSpec extends MutableScalatraSpec {
+  addServlet(new ScalatraServlet with FutureSupport with ScalateI18nSupport {
+
+    protected implicit def executor: ExecutionContext = ExecutionContext.global
+
+    get("/") {
+      Future {
+        mustache("hello.mustache")
+      }
+    }
+
+  }, "/*")
+
+  "I18nSupport should work with Futures" in {
+    get("/") {
+      status should beEqualTo(200)
+    }
+  }
+
+}


### PR DESCRIPTION
Some DSL methods accessed request/response directly, which made them not safe with multi-threading. I added request/response implicits to all DSL methods.

This fixes #435.