### PR TITLE
CorsSupport can be disabled

### DIFF
--- a/core/src/test/scala/org/scalatra/CorsSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/CorsSupportSpec.scala
@@ -54,3 +54,31 @@ class CorsSupportSpec extends ScalatraSpec {
     }
   }
 }
+
+class DisabledCorsSupportSpec extends ScalatraSpec {
+
+  addServlet(new ScalatraServlet with CorsSupport {
+
+    get("/") { "OK" }
+
+    override def initialize(config: ConfigT) {
+      config.context.setInitParameter(CorsSupport.AllowedOriginsKey, "http://www.example.com")
+      config.context.setInitParameter(CorsSupport.AllowedHeadersKey, "X-Requested-With,Authorization,Content-Type,Accept,Origin")
+      config.context.setInitParameter(CorsSupport.AllowedMethodsKey, "GET,HEAD,POST")
+      config.context.setInitParameter(CorsSupport.EnableKey, "false")
+      super.initialize(config)
+    }
+  }, "/disabled")
+
+  def is =
+    "The CORS support should" ^
+      "be disabled with configuration" ! context.simpleRequestToDisabledCors ^ end
+
+  object context {
+    def simpleRequestToDisabledCors = {
+      get("/disabled/", headers = Map(CorsSupport.OriginHeader -> "http://www.example.com")) {
+        response.getHeader(CorsSupport.AccessControlAllowOriginHeader) must_== null
+      }
+    }
+  }
+}


### PR DESCRIPTION
CorsSupport can be disabled with context.initParameters("org.scalatra.cors.enable") = false

We're developing a few scalatra apps that we'd like to use so that cors is enabled for development servers and disabled in production. Now it's easy to disable and enable the cors.