### PR TITLE
Copy from input stream in a loop to ensure full copy for files over 2GB

### DIFF
--- a/core/src/main/scala/org/scalatra/util/io/package.scala
+++ b/core/src/main/scala/org/scalatra/util/io/package.scala
@@ -33,7 +33,13 @@ package object io {
   }
 
   def zeroCopy(in: FileInputStream, out: OutputStream): Unit = {
-    using(in.getChannel) { ch => ch.transferTo(0, ch.size, Channels.newChannel(out)) }
+    using(in.getChannel) {
+      ch =>
+        var start = 0L
+        while (start < ch.size) {
+          start += ch.transferTo(start, ch.size, Channels.newChannel(out))
+        }
+    }
   }
 
   def readBytes(in: InputStream): Array[Byte] = {


### PR DESCRIPTION
This fixes #575 