### PR TITLE
Add responseModel property to the response message

### DIFF
--- a/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
+++ b/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
@@ -58,7 +58,7 @@ object SwaggerAuthSerializers {
         (value \ "deprecated").extractOpt[Boolean] getOrElse false,
         (value \ "nickname").extractOpt[String].flatMap(_.blankOption),
         (value \ "parameters").extract[List[Parameter]],
-        (value \ "responseMessages").extract[List[ResponseMessage[_]]],
+        (value \ "responseMessages").extract[List[ResponseMessage]],
         (value \ "consumes").extract[List[String]],
         (value \ "produces").extract[List[String]],
         (value \ "protocols").extract[List[String]],
@@ -246,7 +246,7 @@ case class AuthOperation[TypeForUser <: AnyRef](method: HttpMethod,
   deprecated: Boolean = false,
   nickname: Option[String] = None,
   parameters: List[Parameter] = Nil,
-  responseMessages: List[ResponseMessage[_]] = Nil,
+  responseMessages: List[ResponseMessage] = Nil,
   consumes: List[String] = Nil,
   produces: List[String] = Nil,
   protocols: List[String] = Nil,
@@ -294,7 +294,7 @@ trait SwaggerAuthSupport[TypeForUser <: AnyRef] extends SwaggerSupportBase with 
     val op = route.metadata.get(Symbols.Operation) map (_.asInstanceOf[AuthOperation[TypeForUser]])
     op map (_.copy(method = method)) getOrElse {
       val theParams = route.metadata.get(Symbols.Parameters) map (_.asInstanceOf[List[Parameter]]) getOrElse Nil
-      val errors = route.metadata.get(Symbols.Errors) map (_.asInstanceOf[List[ResponseMessage[_]]]) getOrElse Nil
+      val errors = route.metadata.get(Symbols.Errors) map (_.asInstanceOf[List[ResponseMessage]]) getOrElse Nil
       val responseClass = route.metadata.get(Symbols.ResponseClass) map (_.asInstanceOf[DataType]) getOrElse DataType.Void
       val summary = (route.metadata.get(Symbols.Summary) map (_.asInstanceOf[String])).orNull
       val notes = route.metadata.get(Symbols.Notes) map (_.asInstanceOf[String])

--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -487,8 +487,8 @@ trait SwaggerOperation {
   def authorizations: List[String]
   def parameters: List[Parameter]
   @deprecated("Swagger spec 1.2 renamed `errorResponses` to `responseMessages`.", "2.2.2")
-  def errorResponses: List[ResponseMessage[_]] = responseMessages
-  def responseMessages: List[ResponseMessage[_]]
+  def errorResponses: List[ResponseMessage] = responseMessages
+  def responseMessages: List[ResponseMessage]
   //  def supportedContentTypes: List[String]
   def position: Int
 }
@@ -500,7 +500,7 @@ case class Operation(method: HttpMethod,
   deprecated: Boolean = false,
   nickname: Option[String] = None,
   parameters: List[Parameter] = Nil,
-  responseMessages: List[ResponseMessage[_]] = Nil,
+  responseMessages: List[ResponseMessage] = Nil,
   //                     supportedContentTypes: List[String] = Nil,
   consumes: List[String] = Nil,
   produces: List[String] = Nil,
@@ -517,8 +517,4 @@ case class Endpoint(path: String,
   description: Option[String] = None,
   operations: List[Operation] = Nil) extends SwaggerEndpoint[Operation]
 
-trait ResponseMessage[T] {
-  def code: Int
-  def message: T
-}
-case class StringResponseMessage(code: Int, message: String) extends ResponseMessage[String]
+case class ResponseMessage(code: Int, message: String, responseModel: Option[String] = None)

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
@@ -275,12 +275,12 @@ object SwaggerSerializers {
         ("properties" -> (x.properties.sortBy { case (_, p) ⇒ p.position } map { case (k, v) => k -> Extraction.decompose(v) }))
   }))
 
-  class ResponseMessageSerializer extends CustomSerializer[ResponseMessage[_]](implicit formats => ({
+  class ResponseMessageSerializer extends CustomSerializer[ResponseMessage](implicit formats => ({
     case value: JObject =>
-      StringResponseMessage((value \ "code").as[Int], (value \ "message").as[String])
+      ResponseMessage((value \ "code").as[Int], (value \ "message").as[String], (value \ "responseModel").getAs[String].flatMap(_.blankOption))
   }, {
-    case StringResponseMessage(code, message) =>
-      ("code" -> code) ~ ("message" -> message)
+    case ResponseMessage(code, message, responseModel) =>
+      ("code" -> code) ~ ("message" -> message) ~ ("responseModel" -> responseModel)
   }))
 
   class ParameterSerializer extends CustomSerializer[Parameter](implicit formats => ({
@@ -332,7 +332,7 @@ object SwaggerSerializers {
         (value \ "deprecated").extractOpt[Boolean] getOrElse false,
         (value \ "nickname").extractOpt[String].flatMap(_.blankOption),
         (value \ "parameters").extract[List[Parameter]],
-        (value \ "responseMessages").extract[List[ResponseMessage[_]]],
+        (value \ "responseMessages").extract[List[ResponseMessage]],
         (value \ "consumes").extract[List[String]],
         (value \ "produces").extract[List[String]],
         (value \ "protocols").extract[List[String]],

--- a/swagger/src/main/scala/org/scalatra/swagger/package.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/package.scala
@@ -42,6 +42,6 @@ package object swagger {
 
     type ApiEnum = org.scalatra.swagger.runtime.annotations.ApiEnum
     @deprecated("In swagger spec 1.2 this was replaced with org.scalatra.swagger.ResponseMessage", "2.2.2")
-    type Error = org.scalatra.swagger.ResponseMessage[String]
+    type Error = org.scalatra.swagger.ResponseMessage
   }
 }

--- a/swagger/src/test/resources/pet.json
+++ b/swagger/src/test/resources/pet.json
@@ -38,7 +38,8 @@
           "responseMessages": [
             {
               "code": 400,
-              "message": "Invalid ID supplied"
+              "message": "Invalid ID supplied",
+              "responseModel": "Error"
             },
             {
               "code": 404,
@@ -210,6 +211,15 @@
     }
   ],
   "models": {
+    "Error": {
+      "id": "Error",
+      "properties": {
+        "message": {
+          "position" : 0,
+          "type": "string"
+        }
+      }
+    },
     "Tag": {
       "id": "Tag",
       "properties": {


### PR DESCRIPTION
This pull request is fix for #577. It makes possible to define `responseModel` for the response message as follows:
```scala
responseMessages (
  ResponseMessage(400, "Invalid ID supplied").model[Error], 
  ResponseMessage(404, "Pet not found")
)
```