### PR TITLE
Swagger 2.0 support

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -47,11 +47,8 @@ trait SwaggerEngine[T <: SwaggerApi[_]] {
 
 object Swagger {
 
-  val baseTypes = Set("byte", "boolean", "int", "long", "float", "double", "string", "date", "void", "Date", "DateTime", "DateMidnight", "Duration", "FiniteDuration", "Chronology")
-  val excludes: Set[java.lang.reflect.Type] = Set(classOf[java.util.TimeZone], classOf[java.util.Date], classOf[DateTime], classOf[DateMidnight], classOf[ReadableInstant], classOf[Chronology], classOf[DateTimeZone])
-  val containerTypes = Set("Array", "List", "Set")
+  val excludes: Set[java.lang.reflect.Type] = Set(classOf[java.util.TimeZone], classOf[java.util.Date], classOf[DateTime], classOf[LocalDate], classOf[ReadableInstant], classOf[Chronology], classOf[DateTimeZone])
   val SpecVersion = "1.2"
-  val Iso8601Date = ISODateTimeFormat.dateTime.withZone(DateTimeZone.UTC)
 
   def collectModels[T: Manifest](alreadyKnown: Set[Model]): Set[Model] = collectModels(Reflector.scalaTypeOf[T], alreadyKnown)
   private[swagger] def collectModels(tpe: ScalaType, alreadyKnown: Set[Model], known: Set[ScalaType] = Set.empty): Set[Model] = {
@@ -367,7 +364,7 @@ object DataType {
   private[this] def isDecimal(klass: Class[_]) = DecimalTypes contains klass
 
   private[this] val DateTypes =
-    Set[Class[_]](classOf[DateMidnight])
+    Set[Class[_]](classOf[LocalDate])
   private[this] def isDate(klass: Class[_]) = DateTypes.exists(_.isAssignableFrom(klass))
   private[this] val DateTimeTypes =
     Set[Class[_]](classOf[JDate], classOf[DateTime])

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -4,6 +4,7 @@ package swagger
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.scalatra.json.JsonSupport
+import org.scalatra.swagger.DataType.{ContainerDataType, ValueDataType}
 
 /**
  * Trait that serves the resource and operation listings, as specified by the Swagger specification.
@@ -16,6 +17,16 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
   protected def docToJson(doc: ApiType): JValue
 
   implicit override def string2RouteMatcher(path: String) = new RailsRouteMatcher(path)
+
+  implicit class JsonAssocNonEmpty(left: JObject) {
+    def ~!(right: JObject): JObject = {
+      right.obj.headOption match {
+        case Some((_, JArray(arr))) if arr.isEmpty => left.obj
+        case Some((_, JObject(fs))) if fs.isEmpty => left.obj
+        case _ => JObject(left.obj ::: right.obj)
+      }
+    }
+  }
 
   /**
    * The name of the route to use when getting the index listing for swagger
@@ -33,20 +44,26 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
 
   abstract override def initialize(config: ConfigT) {
     super.initialize(config)
-    get("""/([^.]+)*(?:\.(\w+))?""".r) {
-      val doc :: fmt :: Nil = multiParams("captures").toList
-      if (fmt != null) format = fmt
-      swagger.doc(doc) match {
-        case Some(d) ⇒ renderDoc(d.asInstanceOf[ApiType])
-        case _ ⇒ halt(404)
+    if(swagger.swaggerVersion.startsWith("2.")){
+      get("/swagger.json") {
+        renderSwagger2(swagger.docs.toList.asInstanceOf[List[ApiType]])
       }
-    }
+    } else {
+      get("""/([^.]+)*(?:\.(\w+))?""".r) {
+        val doc :: fmt :: Nil = multiParams("captures").toList
+        if (fmt != null) format = fmt
+        swagger.doc(doc) match {
+          case Some(d) ⇒ renderDoc(d.asInstanceOf[ApiType])
+          case _ ⇒ halt(404)
+        }
+      }
 
-    get("/(" + indexRoute + "(.:format))") {
-      renderIndex(swagger.docs.toList.asInstanceOf[List[ApiType]])
-    }
+      get("/(" + indexRoute + "(.:format))") {
+        renderIndex(swagger.docs.toList.asInstanceOf[List[ApiType]])
+      }
 
-    options("/(" + indexRoute + "(.:format))") {}
+      options("/(" + indexRoute + "(.:format))") {}
+    }
   }
 
   /**
@@ -86,6 +103,111 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
           acc merge JObject(List(auth.`type` -> Extraction.decompose(auth)))
         }) ~
         ("info" -> Option(swagger.apiInfo).map(Extraction.decompose(_)))
+  }
+
+  private[this] def generateDataType(dataType: DataType): List[JField] = {
+    dataType match {
+      case t: ValueDataType if t.qualifiedName.isDefined =>
+        List(("$ref" -> s"#/definitions/${t.name}"))
+      case t: ValueDataType =>
+        List(("type" -> t.name), ("format" -> t.format))
+      case t: ContainerDataType =>
+        List(("type" -> "array"), ("items" -> generateDataType(t.typeArg.get)))
+    }
+  }
+
+  protected def renderSwagger2(docs: List[ApiType]): JValue = {
+    ("swagger" -> "2.0") ~
+      ("info" ->
+        ("title" -> swagger.apiInfo.title) ~
+        ("version" -> swagger.apiVersion) ~
+        ("description" -> swagger.apiInfo.description) ~
+        ("termsOfService" -> swagger.apiInfo.termsOfServiceUrl) ~
+        ("contact" -> (
+          ("name" -> swagger.apiInfo.contact))) ~
+        ("license" -> (
+          ("name" -> swagger.apiInfo.license) ~
+            ("url" -> swagger.apiInfo.licenseUrl)))) ~
+      ("paths" ->
+        (docs.filter(_.apis.nonEmpty).flatMap {
+          doc => doc.apis.collect { case api: Endpoint =>
+            (api.path -> api.operations.map { operation =>
+              (operation.method.toString.toLowerCase -> (
+                ("operationId" -> operation.nickname) ~
+                ("summary" -> operation.summary) ~!
+                ("schemes" -> operation.protocols) ~!
+                ("consumes" -> operation.consumes) ~!
+                ("produces" -> operation.produces) ~
+                ("parameters" -> operation.parameters.map { parameter =>
+                  ("name" -> parameter.name) ~
+                    ("description" -> parameter.description) ~
+                    ("required" -> parameter.required) ~
+                    ("in" -> parameter.paramType.toString.toLowerCase) ~~
+                    (if (parameter.paramType.toString.toLowerCase == "body") {
+                      List(JField("schema", JObject(JField("$ref", s"#/definitions/${parameter.`type`.name}"))))
+                    } else {
+                      generateDataType(parameter.`type`)
+                    })
+                  }) ~
+                  ("responses" ->
+                    ("200" ->
+                      (if(operation.responseClass.name == "void") {
+                        JField("description", "No response")
+                      } else {
+                        JField("schema", generateDataType(operation.responseClass))
+                      })) ~~
+                      operation.responseMessages.map { response =>
+                        (response.code.toString ->
+                          ("description", response.message) ~~
+                          response.responseModel.map { model =>
+                            List(JField("schema", JObject(JField("$ref", s"#/definitions/${model}"))))
+                          }.getOrElse(Nil))
+                      }.toMap
+                    ) ~!
+                  ("security" -> (operation.authorizations.flatMap { requirement =>
+                    swagger.authorizations.find(_.`type` == requirement).map { auth =>
+                      auth match {
+                        case a: OAuth => (requirement -> a.scopes)
+                        case _        => (requirement -> List.empty)
+                      }
+                    }
+                  }).toMap)
+                )
+              )
+            }.toMap)
+          }.toMap
+        }.toMap)) ~
+      ("definitions" -> docs.flatMap { doc =>
+        doc.models.map { case (name, model) =>
+          (name ->
+            ("properties" -> model.properties.map { case (name, property) =>
+              (name -> generateDataType(property.`type`))
+            }.toMap))
+        }
+      }.toMap) ~
+      ("securityDefinitions" -> (swagger.authorizations.flatMap { auth =>
+        (auth match {
+          case a: OAuth => a.grantTypes.headOption.map { grantType =>
+            grantType match {
+              case g: ImplicitGrant => ("oauth2" -> JObject(
+                JField("type", "oauth2"),
+                JField("flow", "implicit"),
+                JField("authorizationUrl", g.loginEndpoint.url),
+                JField("scopes", a.scopes.map(scope => JField(scope, scope)))))
+              case g: AuthorizationCodeGrant => ("oauth2" -> JObject(
+                JField("type", "oauth2"),
+                JField("flow", "implicit"),
+                JField("authorizationUrl", g.tokenRequestEndpoint.url),
+                JField("tokenUrl", g.tokenEndpoint.url),
+                JField("scopes", a.scopes.map(scope => JField(scope, scope)))))
+            }
+          }
+          case a: ApiKey => Some(("api_key" -> JObject(
+            JField("type", "apiKey"),
+            JField("name", a.keyname),
+            JField("in", a.passAs))))
+        })
+      }).toMap)
   }
 
   error {

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -1,0 +1,418 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Sample App",
+    "version": "1.0.0",
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "apiteam@wordnik.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/store/order": {
+      "post": {
+        "operationId": "placeOrder",
+        "summary": "Place an order for a pet",
+        "parameters": [
+          {
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "No response"
+          },
+          "400": {
+            "description": "Invalid order"
+          }
+        }
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "operationId": "findPetsByTags",
+        "summary": "Finds Pets by tags",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "description": "Tags to filter by",
+            "required": true,
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "delete": {
+        "operationId": "deleteOrder",
+        "summary": "Delete purchase order by ID",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "No response"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "get": {
+        "operationId": "getOrderById",
+        "summary": "Find purchase order by ID",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "in": "path",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user/": {
+      "post": {
+        "operationId": "createUser",
+        "summary": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}": {
+      "delete": {
+        "operationId": "deletePet",
+        "summary": "Deletes a pet",
+        "parameters": [
+          {
+            "name": "petId",
+            "description": "Pet id to delete",
+            "required": true,
+            "in": "path",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "No response"
+          },
+          "400": {
+            "description": "Invalid pet value"
+          }
+        }
+      },
+      "get": {
+        "operationId": "getPetById",
+        "summary": "Find pet by ID",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "in": "path",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": {
+          "oauth2": [
+            "PUBLIC"
+          ]
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "operationId": "findPetsByStatus",
+        "summary": "Finds Pets by status",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        }
+      }
+    },
+    "/pet/": {
+      "post": {
+        "operationId": "addPet",
+        "summary": "Add a new pet to the store",
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "No response"
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        }
+      },
+      "put": {
+        "operationId": "updatePet",
+        "summary": "Update an existing pet",
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Pet object that needs to be updated in the store",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "No response"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "photoUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "status": {
+          "type": "string"
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        }
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "User": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "Order": {
+      "properties": {
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "oauth2": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "http://localhost:8002/oauth/dialog",
+      "scopes": {
+        "PUBLIC": "PUBLIC"
+      }
+    },
+    "api_key": {
+      "type": "apiKey",
+      "name": "apiKey",
+      "in": "header"
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.4.3-SNAPSHOT"
+version in ThisBuild := "2.5.0-SNAPSHOT"


### PR DESCRIPTION
This generates Swagger 2.0 JSON from existing metadata of Swagger support in Scalatra. You have to modify only the Swagger version defined in metadata "2.0" as follows:

``` scala
class IndexSwagger extends Swagger("2.0", "1", ApiInfo(
  title = "Swagger Sample App",
  description = "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.",
  termsOfServiceUrl = "http://helloreverb.com/terms/",
  contact = "apiteam@wordnik.com",
  license = "Apache 2.0",
  licenseUrl = "http://www.apache.org/licenses/LICENSE-2.0.html"
))
```

Generated Swagger 2.0 JSON example is here: https://github.com/takezoe/scalatra/blob/topic/swagger-2.0/swagger/src/test/resources/swagger.json
