### PR TITLE
Specify Locale as ENGLISH for HttpDate pattern

### DIFF
--- a/commands/src/main/scala/org/scalatra/commands/JodaDateFormats.scala
+++ b/commands/src/main/scala/org/scalatra/commands/JodaDateFormats.scala
@@ -47,7 +47,7 @@ object JodaDateFormats extends DateParser {
 
   object HttpDate extends DateFormat {
     val pattern = "EEE, dd MMM yyyy HH:mm:ss zzz"
-    val dateTimeFormat = DateTimeFormat.forPattern(pattern)
+    val dateTimeFormat = DateTimeFormat.forPattern(pattern).withLocale(Locale.ENGLISH)
 
     override def parse(s: String) = {
       s.blankOption flatMap { s ⇒


### PR DESCRIPTION
Because some tests are failing in environment that the default locale is not ENGLISH.