### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/core/src/main/scala/org/scalatra/util/Mimes.scala
+++ b/core/src/main/scala/org/scalatra/util/Mimes.scala
@@ -7,7 +7,7 @@ import eu.medsea.mimeutil.{ MimeType, MimeUtil2 }
 import eu.medsea.util.EncodingGuesser
 import grizzled.slf4j.Logger
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.control.Exception._
 
 object Mimes {
@@ -22,7 +22,7 @@ object Mimes {
     synchronized {
       if (EncodingGuesser.getSupportedEncodings.isEmpty) {
         val enc = Set("UTF-8", "ISO-8859-1", "windows-1252", "MacRoman", EncodingGuesser.getDefaultEncoding)
-        EncodingGuesser.setSupportedEncodings(enc)
+        EncodingGuesser.setSupportedEncodings(enc.asJava)
       }
     }
   }

--- a/core/src/test/scala/org/scalatra/servlet/FileUploadSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/servlet/FileUploadSupportSpec.scala
@@ -5,11 +5,11 @@ import java.io.File
 import org.scalatra.ScalatraServlet
 import org.scalatra.test.specs2.MutableScalatraSpec
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class FileUploadSupportSpecServlet extends ScalatraServlet with FileUploadSupport {
   def headersToHeaders() {
-    request.getHeaderNames.filter(_.startsWith("X")).foreach(header =>
+    request.getHeaderNames.asScala.filter(_.startsWith("X")).foreach(header =>
       response.setHeader(header, request.getHeader(header))
     )
   }

--- a/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
+++ b/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
@@ -5,14 +5,14 @@ import java.io.File
 import org.scalatra.ScalatraServlet
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class FileUploadTestHelpersTestServlet extends ScalatraServlet with FileUploadSupport {
   def handleRequest() {
     response.setHeader("Request-Method", request.getMethod)
     params.foreach(p => response.setHeader("Param-" + p._1, p._2))
 
-    request.getHeaderNames.filter(header => header.startsWith("Test-")).foreach(header =>
+    request.getHeaderNames.asScala.filter(header => header.startsWith("Test-")).foreach(header =>
       response.setHeader(header, request.getHeader(header))
     )
 

--- a/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
+++ b/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeAfterAll
 
 import scala.annotation.tailrec
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class HttpComponentsClientSpec
     extends Specification
@@ -35,10 +35,10 @@ class HttpComponentsClientSpec
 
       resp.setHeader("Request-Method", req.getMethod.toUpperCase)
       resp.setHeader("Request-URI", req.getRequestURI)
-      req.getHeaderNames.foreach(headerName =>
+      req.getHeaderNames.asScala.foreach(headerName =>
         resp.setHeader("Request-Header-%s".format(headerName), req.getHeader(headerName)))
 
-      req.getParameterMap.foreach {
+      req.getParameterMap.asScala.foreach {
         case (name, values) =>
           resp.setHeader("Request-Param-%s".format(name), values.mkString(", "))
       }


### PR DESCRIPTION
JavaConversions is deprecated since Scala 2.12
https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/JavaConversions.scala#L59