### PR TITLE
 Correction of the error in swagger when placing a variable of type R…

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -53,7 +53,7 @@ object Swagger {
   def collectModels[T: Manifest](alreadyKnown: Set[Model]): Set[Model] = collectModels(Reflector.scalaTypeOf[T], alreadyKnown)
   private[swagger] def collectModels(tpe: ScalaType, alreadyKnown: Set[Model], known: Set[ScalaType] = Set.empty): Set[Model] = {
     if (tpe.isMap) collectModels(tpe.typeArgs.head, alreadyKnown, tpe.typeArgs.toSet) ++ collectModels(tpe.typeArgs.last, alreadyKnown, tpe.typeArgs.toSet)
-    else if (tpe.isCollection || tpe.isOption) {
+    else if ((tpe.isCollection && tpe.typeArgs.headOption.isDefined) || (tpe.isOption && tpe.typeArgs.headOption.isDefined))  {
       val ntpe = tpe.typeArgs.head
       if (!known.contains(ntpe)) collectModels(ntpe, alreadyKnown, known + ntpe)
       else Set.empty


### PR DESCRIPTION
…ange in the attributes of request

Correction of the error in swagger when placing a variable of type Range in the attributes of request:

When you place a Range variable in the specified request for the swagger map, the error below happens:

CAUSED BY java.util.NoSuchElementException: head of empty list

![image pasted at 2017-1-4 13-50_preview](https://cloud.githubusercontent.com/assets/18665706/21716078/5439e25c-d3ef-11e6-93db-db07c1de5fa3.jpg)

The applied correction validates if the head is empty.