### PR TITLE
add support for swagger2 application grant

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -468,6 +468,10 @@ case class AuthorizationCodeGrant(
     tokenEndpoint: TokenEndpoint) extends GrantType {
   def `type` = "authorization_code"
 }
+case class ApplicationGrant(
+    tokenEndpoint: TokenEndpoint) extends GrantType {
+  def `type` = "application"
+}
 trait SwaggerOperation {
   @deprecated("Swagger spec 1.2 renamed `httpMethod` to `method`.", "2.2.2")
   def httpMethod: HttpMethod = method

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -200,6 +200,11 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                 JField("authorizationUrl", g.tokenRequestEndpoint.url),
                 JField("tokenUrl", g.tokenEndpoint.url),
                 JField("scopes", a.scopes.map(scope => JField(scope, scope)))))
+              case g: ApplicationGrant => ("oauth2" -> JObject(
+                JField("type", "oauth2"),
+                JField("flow", "application"),
+                JField("tokenUrl", g.tokenEndpoint.url),
+                JField("scopes", a.scopes.map(scope => JField(scope, scope)))))
             }
           }
           case a: ApiKey => Some(("api_key" -> JObject(

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -301,7 +301,8 @@ class SwaggerSpec2 extends ScalatraSpec with JsonMatchers {
       ImplicitGrant(LoginEndpoint("http://localhost:8002/oauth/dialog"), "access_code"),
       AuthorizationCodeGrant(
         TokenRequestEndpoint("http://localhost:8002/oauth/requestToken", "client_id", "client_secret"),
-        TokenEndpoint("http://localhost:8002/oauth/token", "access_code"))
+        TokenEndpoint("http://localhost:8002/oauth/token", "access_code")),
+      ApplicationGrant(TokenEndpoint("http://localhost:8002/oauth/token", "access_code"))
     )
   ))
   val testServlet = new SwaggerTestServlet(swagger)


### PR DESCRIPTION
This pull-request adds support for the application grant type for swagger2 oauth flows.
This is currently missing in the swagger2-implementation of scalatra.

Application grant is the swagger-name of the client credentials flow of oauth2.