### PR TITLE
changed to use list for security for an operation for swagger2

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -171,7 +171,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                         case _        => (requirement -> List.empty)
                       }
                     }
-                  }).toMap)
+                  }))
                 )
               )
             }.toMap)

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -190,11 +190,13 @@
             "description": "Pet not found"
           }
         },
-        "security": {
-          "oauth2": [
-            "PUBLIC"
-          ]
-        }
+        "security": [
+          {
+            "oauth2": [
+              "PUBLIC"
+            ]
+          }
+        ]
       }
     },
     "/pet/findByStatus": {


### PR DESCRIPTION
The Swagger 2.0 specification states that security for an operation should be a list.
The current swagger2-implementation in scalatra generates the following:

```
"security": {
   "oauth2": [
      "PUBLIC"
   ]
}
```

This PR changes the above to this (which is correct according to the spec):
```
"security": [
   {
      "oauth2": [
         "PUBLIC"
      ]
   }
]
```