### PR TITLE
Added swagger description OK for response 200

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -152,10 +152,10 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                   ("responses" ->
                     ("200" ->
                       (if(operation.responseClass.name == "void") {
-                        JField("description", "No response")
+                        List(JField("description", "No response"))
                       } else {
-                        JField("schema", generateDataType(operation.responseClass))
-                      })) ~~
+                        List(JField("description", "OK"), JField("schema", generateDataType(operation.responseClass)))
+                      })) ~
                       operation.responseMessages.map { response =>
                         (response.code.toString ->
                           ("description", response.message) ~~

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -61,6 +61,7 @@
         ],
         "responses": {
           "200": {
+            "description": "OK",
             "schema": {
               "type": "array",
               "items": {
@@ -109,6 +110,7 @@
         ],
         "responses": {
           "200": {
+            "description": "OK",
             "schema": {
               "$ref": "#/definitions/Order"
             }
@@ -129,6 +131,7 @@
         "parameters": [],
         "responses": {
           "200": {
+            "description": "OK",
             "schema": {
               "$ref": "#/definitions/User"
             }
@@ -176,6 +179,7 @@
         ],
         "responses": {
           "200": {
+            "description": "OK",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
@@ -219,6 +223,7 @@
         ],
         "responses": {
           "200": {
+            "description": "OK",
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
The current swagger2-implementation of a 200 response generates a response object containing a schema-element with a reference to a model. The swagger2-specification states that a response should either be a pure reference object or a response object. 

This PR changes the default of a 200 response to also include the description:

Before PR:
```
"200": {
   "schema": {
      "$ref": "#/definitions/Order"
   }
}
```

After PR:
```
"200": {
   "description": "OK",
   "schema": {
      "$ref": "#/definitions/Order"
   }
}
```