### PR TITLE
Mapping form to formData for swagger2

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -210,8 +210,8 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
       }).toMap)
   }
 
-  def swagger2ParamTypeMapping(paramTypeName: String): String = {
-    Map("form" -> "formData").getOrElse(paramTypeName, paramTypeName)
+  private def swagger2ParamTypeMapping(paramTypeName: String): String = {
+    if (paramTypeName == "form") "formData" else paramTypeName
   }
 
   error {

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -142,7 +142,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                   ("name" -> parameter.name) ~
                     ("description" -> parameter.description) ~
                     ("required" -> parameter.required) ~
-                    ("in" -> parameter.paramType.toString.toLowerCase) ~~
+                    ("in" -> swagger2ParamTypeMapping(parameter.paramType.toString.toLowerCase)) ~~
                     (if (parameter.paramType.toString.toLowerCase == "body") {
                       List(JField("schema", JObject(JField("$ref", s"#/definitions/${parameter.`type`.name}"))))
                     } else {
@@ -208,6 +208,10 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
             JField("in", a.passAs))))
         })
       }).toMap)
+  }
+
+  def swagger2ParamTypeMapping(paramTypeName: String): String = {
+    Map("form" -> "formData").getOrElse(paramTypeName, paramTypeName)
   }
 
   error {


### PR DESCRIPTION
Between Swagger 1.2 and Swagger 2.0, the name of the parameter-type form changed from "form" to "formData".

This PR uses the "formData" name for rendring of swagger2 parameters.