### PR TITLE
Update ScalatraBase.scala

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -735,7 +735,7 @@ trait ScalatraBase
       implicit request: HttpServletRequest, response: HttpServletResponse): String = {
     if (path.startsWith("http")) path
     else {
-      val p = url(path, params, includeContextPath, includeServletPath, withSessionId)
+      val p = url(path, params, includeContextPath, includeServletPath, withSessionId = withSessionId)
       if (p.startsWith("http")) p else buildBaseUrl + ensureSlash(p)
     }
   }


### PR DESCRIPTION
withSessionId currently maps to url(absolutize), remapping it to propagate correctly to url(withSessionId)