### PR TITLE
s/newInstance()/getDeclaredConstructor().newInstance()

### DIFF
--- a/auth/src/main/scala/org/scalatra/auth/ScentrySupport.scala
+++ b/auth/src/main/scala/org/scalatra/auth/ScentrySupport.scala
@@ -39,7 +39,7 @@ trait ScentrySupport[UserType <: AnyRef] extends Initializable {
     }
 
   private def registerStrategiesFromConfig = _strategiesFromConfig foreach { strategyClassName ⇒
-    val strategy = Class.forName(strategyClassName).newInstance.asInstanceOf[ScentryStrategy[UserType]]
+    val strategy = Class.forName(strategyClassName).getDeclaredConstructor().newInstance().asInstanceOf[ScentryStrategy[UserType]]
     strategy registerWith scentry
   }
 

--- a/commands/src/main/scala/org/scalatra/commands/CommandSupport.scala
+++ b/commands/src/main/scala/org/scalatra/commands/CommandSupport.scala
@@ -29,7 +29,7 @@ trait CommandSupport extends ParamsValueReaderProperties with CommandExecutors {
    * a request attribute.
    */
   def command[T <: CommandType](implicit request: HttpServletRequest, mf: Manifest[T]): T = {
-    def createCommand = commandFactories.get(mf.runtimeClass).map(_()).getOrElse(mf.runtimeClass.newInstance()).asInstanceOf[T]
+    def createCommand = commandFactories.get(mf.runtimeClass).map(_()).getOrElse(mf.runtimeClass.getDeclaredConstructor().newInstance()).asInstanceOf[T]
     commandOption[T] getOrElse bindCommand(createCommand)
   }
 

--- a/core/src/main/scala/org/scalatra/servlet/ScalatraListener.scala
+++ b/core/src/main/scala/org/scalatra/servlet/ScalatraListener.scala
@@ -52,7 +52,7 @@ class ScalatraListener extends ServletContextListener {
 
     if (cycleClass.getName == OldDefaultLifeCycle)
       logger.warn("The Scalatra name for a boot class will be removed eventually. Please use ScalatraBootstrap instead as class name.")
-    (cycleClass.getSimpleName, cycleClass.newInstance.asInstanceOf[LifeCycle])
+    (cycleClass.getSimpleName, cycleClass.getDeclaredConstructor().newInstance().asInstanceOf[LifeCycle])
   }
 
   protected def configureServletContext(sce: ServletContextEvent): Unit = {

--- a/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerCommand.scala
+++ b/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerCommand.scala
@@ -67,7 +67,7 @@ object SwaggerCommandSupport {
 
   class CommandOperationBuilder[B <: SwaggerOperationBuilder[_]](registerModel: Model => Unit, underlying: B) {
     def parametersFromCommand[C <: Command: Manifest]: B =
-      parametersFromCommand(manifest[C].runtimeClass.newInstance().asInstanceOf[C])
+      parametersFromCommand(manifest[C].runtimeClass.getDeclaredConstructor().newInstance().asInstanceOf[C])
 
     def parametersFromCommand[C <: Command: Manifest](cmd: => C): B = {
       SwaggerCommandSupport.parametersFromCommand(cmd) match {
@@ -95,7 +95,7 @@ trait SwaggerCommandSupport { this: ScalatraBase with SwaggerSupportBase with Sw
     new CommandOperationBuilder(registerModel(_), underlying)
 
   private[this] def parametersFromCommand[T <: CommandType](implicit mf: Manifest[T]): List[Parameter] = {
-    parametersFromCommand(mf.runtimeClass.newInstance().asInstanceOf[T])
+    parametersFromCommand(mf.runtimeClass.getDeclaredConstructor().newInstance().asInstanceOf[T])
   }
 
   private[this] def parametersFromCommand[T <: CommandType](cmd: => T)(implicit mf: Manifest[T]): List[Parameter] = {


### PR DESCRIPTION
java.lang.Class#newInstance deprecated since Java 9

http://download.java.net/java/jdk9/docs/api/java/lang/Class.html#newInstance--