### PR TITLE
Swagger 2.0 tags support

### DIFF
--- a/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
+++ b/swagger-ext/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
@@ -226,6 +226,7 @@ object AuthApi {
       produces,
       protocols,
       authorizations,
+      tags,
       allows
     )
   }
@@ -249,6 +250,7 @@ case class AuthOperation[TypeForUser <: AnyRef](method: HttpMethod,
   produces: List[String] = Nil,
   protocols: List[String] = Nil,
   authorizations: List[String] = Nil,
+  tags: List[String] = Nil,
   allows: Option[TypeForUser] => Boolean = (_: Option[TypeForUser]) => true) extends SwaggerOperation
 
 trait SwaggerAuthSupport[TypeForUser <: AnyRef] extends SwaggerSupportBase with SwaggerSupportSyntax { self: ScalatraBase with ScentrySupport[TypeForUser] =>

--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -486,6 +486,7 @@ trait SwaggerOperation {
   def errorResponses: List[ResponseMessage] = responseMessages
   def responseMessages: List[ResponseMessage]
   //  def supportedContentTypes: List[String]
+  def tags: List[String]
   def position: Int
 }
 case class Operation(method: HttpMethod,
@@ -501,7 +502,8 @@ case class Operation(method: HttpMethod,
   consumes: List[String] = Nil,
   produces: List[String] = Nil,
   protocols: List[String] = Nil,
-  authorizations: List[String] = Nil) extends SwaggerOperation
+  authorizations: List[String] = Nil,
+  tags: List[String] = Nil) extends SwaggerOperation
 
 trait SwaggerEndpoint[T <: SwaggerOperation] {
   def path: String

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -137,7 +137,8 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                 ("summary" -> operation.summary) ~!
                 ("schemes" -> operation.protocols) ~!
                 ("consumes" -> operation.consumes) ~!
-                ("produces" -> operation.produces) ~
+                ("produces" -> operation.produces) ~!
+                ("tags" -> operation.tags) ~
                 ("parameters" -> operation.parameters.map { parameter =>
                   ("name" -> parameter.name) ~
                     ("description" -> parameter.description) ~

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -229,6 +229,7 @@ object SwaggerSupportSyntax {
     private[this] var _consumes: List[String] = Nil
     private[this] var _protocols: List[String] = Nil
     private[this] var _authorizations: List[String] = Nil
+    private[this] var _tags: List[String] = Nil
     private[this] var _position: Int = 0
 
     def resultClass: DataType
@@ -266,6 +267,8 @@ object SwaggerSupportSyntax {
     def protocols(values: String*): this.type = { _protocols :::= values.toList; this }
     def authorizations: List[String] = _authorizations
     def authorizations(values: String*): this.type = { _authorizations :::= values.toList; this }
+    def tags: List[String] = _tags
+    def tags(values: String*): this.type = { _tags :::= values.toList; this }
     def position(value: Int): this.type = { _position = value; this }
     def position: Int = _position
 
@@ -293,7 +296,8 @@ object SwaggerSupportSyntax {
       consumes,
       produces,
       protocols,
-      authorizations)
+      authorizations,
+      tags)
   }
 }
 trait SwaggerSupportSyntax extends Initializable with CorsSupport {

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -18,6 +18,7 @@
       "post": {
         "operationId": "placeOrder",
         "summary": "Place an order for a pet",
+        "tags": ["store"],
         "parameters": [
           {
             "name": "body",
@@ -79,6 +80,7 @@
       "delete": {
         "operationId": "deleteOrder",
         "summary": "Delete purchase order by ID",
+        "tags": ["store"],
         "parameters": [],
         "responses": {
           "200": {
@@ -99,6 +101,7 @@
           "application/json",
           "application/xml"
         ],
+        "tags": ["store"],
         "parameters": [
           {
             "name": "orderId",

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -407,7 +407,7 @@ class SwaggerSpec2 extends ScalatraSpec with JsonMatchers {
   }
 
   def verifyOperation(actual: JValue, expected: JValue, operationId: String) = {
-    val m = verifyFields(actual, expected, "operationId", "summary", "schemes", "consumes", "produces", "parameters", "responses", "security")
+    val m = verifyFields(actual, expected, "operationId", "summary", "schemes", "consumes", "produces", "parameters", "responses", "security", "tags")
     m setMessage (m.message + " of the operation " + operationId)
   }
 
@@ -570,6 +570,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
       summary "Find purchase order by ID"
       notes "For valid response try integer IDs with value <= 5. Anything above 5 or nonintegers will generate API errors"
       produces ("application/json", "application/xml")
+      tags ("store")
       parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched").required
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
@@ -584,6 +585,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
     (apiOperation[Unit]("deleteOrder")
       summary "Delete purchase order by ID"
       notes "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors"
+      tags ("store")
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
         ResponseMessage(404, "Order not found")
@@ -596,6 +598,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
   val placeOrderOperation =
     (apiOperation[Unit]("placeOrder")
       summary "Place an order for a pet"
+      tags ("store")
       responseMessage ResponseMessage(400, "Invalid order")
       parameter bodyParam[Order].description("order placed for purchasing the pet"))
   post("/order", operation(placeOrderOperation)) {


### PR DESCRIPTION
Fixes #626 

This change is keeping source code compatibility, but breaks binary compatibility because contains new properties to the case class. Which version should we merge this in? 2.5.1 or 2.6.0?