### PR TITLE
ScalatraServlet.requestPath: Don't trim encoded semicolons

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -32,10 +32,10 @@ object ScalatraServlet {
   }
 
   def requestPath(uri: String, idx: Int): String = {
-    val u1 = UriDecoder.firstStep(uri)
-    val u2 = (u1.blankOption map { _.substring(idx) } flatMap (_.blankOption) getOrElse "/")
-    val pos = u2.indexOf(';')
-    if (pos > -1) u2.substring(0, pos) else u2
+    val u1 = (uri.blankOption map { _.substring(idx) } flatMap (_.blankOption) getOrElse "/")
+    val pos = u1.indexOf(';')
+    val u2 = if (pos > -1) u1.substring(0, pos) else u1
+    UriDecoder.firstStep(u2)
   }
 
 }

--- a/core/src/test/scala/org/scalatra/ScalatraFilterTest.scala
+++ b/core/src/test/scala/org/scalatra/ScalatraFilterTest.scala
@@ -187,6 +187,16 @@ class ScalatraFilterTest extends ScalatraFunSuite {
       body should equal("?query")
     }
 
+    get("/encoded-uri/%3Bquery") {
+      status should equal(200)
+      body should equal(";query")
+    }
+
+    get("/encoded-uri/%3Bquery;and-some-more-text") {
+      status should equal(200)
+      body should equal(";query")
+    }
+
     get("/encoded-uri/Fu%C3%9Fg%C3%A4nger%C3%BCberg%C3%A4nge%2F%3F%23") {
       status should equal(200)
       body should equal("Fußgängerübergänge/?#")

--- a/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
+++ b/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
@@ -14,11 +14,6 @@ class ScalatraServletRequestPathSpec extends WordSpec with MustMatchers {
       ScalatraServlet.requestPath("/test;test/", 0) must equal("/test")
     }
 
-    "be extracted properly from encoded url" in {
-      ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/")
-      ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/тест/")
-    }
-
     "be extracted properly from decoded url" in {
       ScalatraServlet.requestPath("/тест/", 5) must equal("/")
       ScalatraServlet.requestPath("/тест/тест/", 5) must equal("/тест/")

--- a/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
+++ b/core/src/test/scala/org/scalatra/ScalatraServletRequestPathSpec.scala
@@ -6,6 +6,14 @@ class ScalatraServletRequestPathSpec extends WordSpec with MustMatchers {
 
   "a ScalatraServlet requestPath" should {
 
+    "be extracted properly when encoded url contains semicolon" in {
+      ScalatraServlet.requestPath("/test%3Btest/", 0) must equal("/test;test/")
+    }
+
+    "be extracted properly when url contains semicolon" in {
+      ScalatraServlet.requestPath("/test;test/", 0) must equal("/test")
+    }
+
     "be extracted properly from encoded url" in {
       ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/")
       ScalatraServlet.requestPath("/%D1%82%D0%B5%D1%81%D1%82/%D1%82%D0%B5%D1%81%D1%82/", 5) must equal("/тест/")


### PR DESCRIPTION
Added URIDecoder.firstStepWithoutSemicolon and semicolonStep, using them in ScalatraServlet.requestPath.

__________

##### Original Issue 

Sending the URL : 

```
http://localhost:8080/inspection/input/field/36faeb7b-1254-460b-a87f-9fe55cf410eb/data.request.query.amp%3Bicid/string?onlyDistributions=true
```

The `requestPath` turns to be : 

```
/input/field/36faeb7b-1254-460b-a87f-9fe55cf410eb/data.request.query.amp
```

The bad character is `%3B` (which is decoded to `;`, which truncates the whole url, while it shouldn't, since it's encoded).

Related : #552 #473 