### PR TITLE
Fix Swagger's bodyParam schema generation

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -157,7 +157,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                               ("required" -> parameter.required) ~
                               ("in" -> swagger2ParamTypeMapping(parameter.paramType.toString.toLowerCase)) ~~
                               (if (parameter.paramType.toString.toLowerCase == "body") {
-                                List(JField("schema", JObject(JField("$ref", s"#/definitions/${parameter.`type`.name}"))))
+                                List(JField("schema", generateDataType(parameter.`type`)))
                               } else {
                                 generateDataType(parameter.`type`)
                               })


### PR DESCRIPTION
This pull request fixes #677.

Definition example:
```scala
val register =
  (apiOperation[String]("register")
    parameters (bodyParam[List[String]]))
```

Generated JSON:
```json
{
  "name":"body",
  "required":true,
  "in":"body",
  "schema":{
    "type":"array",
    "items":{
      "type":"string"
    }
  }
}
```