### PR TITLE
Respect order of model properties in Swagger generated JSON

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -86,7 +86,7 @@ object Swagger {
   def modelToSwagger[T](implicit mf: Manifest[T]): Option[Model] = modelToSwagger(Reflector.scalaTypeOf[T])
 
   private[this] def toModelProperty(descr: ClassDescriptor, position: Option[Int] = None, required: Boolean = true, description: Option[String] = None, allowableValues: String = "")(prop: PropertyDescriptor) = {
-    val ctorParam = if (!prop.returnType.isOption) descr.mostComprehensive.find(_.name == prop.name) else None
+    val ctorParam = descr.mostComprehensive.find(_.name == prop.name)
     val mp = ModelProperty(
       DataType.fromScalaType(if (prop.returnType.isOption) prop.returnType.typeArgs.head else prop.returnType),
       if (position.isDefined && position.forall(_ >= 0)) position.get else ctorParam.map(_.argIndex).getOrElse(position.getOrElse(0)),

--- a/swagger/src/test/scala/org/scalatra/swagger/ModelSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/ModelSpec.scala
@@ -19,9 +19,12 @@ object ModelSpec {
   case class WithRequiredValue(id: String, name: String)
   case class WithOptionList(id: String, flags: Option[List[String]])
 
+  case class WithOrder(id: String, name: String, title: Option[String], email: String, company: Option[String])
+
   def swaggerProperties[T](implicit mf: Manifest[T]) = swaggerProperty[T]("id")
-  def swaggerProperty[T](name: String)(implicit mf: Manifest[T]) =
-    Swagger.modelToSwagger(Reflector.scalaTypeOf[T]).get.properties.find(_._1 == name).get._2
+  def swaggerProperty[T](name: String)(implicit mf: Manifest[T]) = allSwaggerProperties[T].find(_._1 == name).get._2
+  def allSwaggerProperties[T](implicit mf: Manifest[T]) =
+    Swagger.modelToSwagger(Reflector.scalaTypeOf[T]).get.properties
 
 }
 
@@ -58,6 +61,9 @@ class ModelSpec extends Specification {
     "conver an option list to a required false list of things" in {
       swaggerProperty[WithOptionList]("flags").required must beFalse
       swaggerProperty[WithOptionList]("flags").`type` must_== DataType[List[String]]
+    }
+    "preserves order of properties" in {
+      allSwaggerProperties[WithOrder].map(_._1) must_== List("id", "name", "title", "email", "company")
     }
 
   }


### PR DESCRIPTION
Fixes #696.

This updates the Swagger JSON generation to keep model properties in the same order they appear in the original class, regardless of whether the property is optional or not.

If this is approved/merged, would it be possible to backport to 2.5.x?