### PR TITLE
Removed unnecessary plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import com.typesafe.sbt.pgp.PgpKeys
 import scala.xml._
 import java.net.URL
-import org.scalatra.sbt.ScalatraPlugin.scalatraWithWarOverlays
 import Dependencies._
 import UnidocKeys._
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"         % "1.0")
 addSbtPlugin("org.scalariform"      % "sbt-scalariform"      % "1.6.0")
-addSbtPlugin("org.scalatra.sbt"     % "scalatra-sbt"         % "0.4.0")
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea"             % "1.6.0")
 addSbtPlugin("com.timushev.sbt"     % "sbt-updates"          % "0.1.10")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"              % "1.0.0")


### PR DESCRIPTION
The WarOverlays plugin is not used,
so scalatra-sbt loading therefor is unnecessary