### PR TITLE
Strip `/?` from urls generated for routes with trailing slash

### DIFF
--- a/core/src/main/scala/org/scalatra/routeMatcher.scala
+++ b/core/src/main/scala/org/scalatra/routeMatcher.scala
@@ -67,11 +67,12 @@ final class SinatraRouteMatcher(pattern: String)
       else this
 
     // checks all splats are used, appends additional params as a query string
+    // strips optional trailing slash from path
     def get: String = {
       if (!splats.isEmpty) throw new Exception("Too many splats for builder \"%s\"" format pattern)
       val pairs = params map { case (key, value) => key.urlEncode + "=" + value.urlEncode }
       val queryString = if (pairs.isEmpty) "" else pairs.mkString("?", "&", "")
-      path + queryString
+      path.replaceFirst("""/\?$""", "") + queryString
     }
   }
 

--- a/core/src/test/scala/org/scalatra/SinatraLikeUrlGeneratorTest.scala
+++ b/core/src/test/scala/org/scalatra/SinatraLikeUrlGeneratorTest.scala
@@ -17,6 +17,10 @@ class SinatraLikeUrlGeneratorTest extends FunSuite with Matchers {
     url("/foo") should equal("/foo")
   }
 
+  test("String route with optional trailing slash reverses to url with no slash") {
+    url("/foo/?") should equal("/foo")
+  }
+
   test("Route with one named parameter replaces the parameter") {
     url("/foo/:bar", "bar" -> "bryan") should equal("/foo/bryan")
   }

--- a/core/src/test/scala/org/scalatra/UrlGeneratorSupportTest.scala
+++ b/core/src/test/scala/org/scalatra/UrlGeneratorSupportTest.scala
@@ -6,6 +6,10 @@ class UrlGeneratorContextTestServlet extends ScalatraServlet with UrlGeneratorSu
   val servletRoute: Route = get("/foo") { url(servletRoute) }
 }
 
+class UrlGeneratorContextWithSlashTestServlet extends ScalatraServlet with UrlGeneratorSupport {
+  val servletRoute: Route = get("/foo/?") { url(servletRoute) }
+}
+
 class UrlGeneratorContextTestFilter extends ScalatraFilter {
   val filterRoute: Route = get("/filtered/foo") {
     UrlGenerator.url(filterRoute)
@@ -33,6 +37,23 @@ class UrlGeneratorSupportTest extends ScalatraFunSuite {
   test("Url of a filter does not duplicate the servlet path") {
     get("/filtered/foo") {
       body should equal("/filtered/foo")
+    }
+  }
+}
+
+class UrlGeneratorOptionalSlashSupportTest extends ScalatraFunSuite {
+  addServlet(new UrlGeneratorContextWithSlashTestServlet, "/*")
+  addServlet(new UrlGeneratorContextWithSlashTestServlet, "/servlet-path/*")
+
+  test("Url of a servlet with optional slash mounted on /*") {
+    get("/foo/") {
+      body should equal("/foo")
+    }
+  }
+
+  test("Url of a servlet mounted on /servlet-path/*") {
+    get("/servlet-path/foo/") {
+      body should equal("/servlet-path/foo")
     }
   }
 }


### PR DESCRIPTION
fixes #713