### PR TITLE
Execute the before action of I18nSupport only once

### DIFF
--- a/core/src/main/scala/org/scalatra/i18n/I18nSupport.scala
+++ b/core/src/main/scala/org/scalatra/i18n/I18nSupport.scala
@@ -19,8 +19,12 @@ trait I18nSupport { this: ScalatraBase =>
   import org.scalatra.i18n.I18nSupport._
 
   before() {
-    request(LocaleKey) = resolveLocale
-    request(MessagesKey) = provideMessages(locale)
+    if (!request.contains(LocaleKey)) {
+      request(LocaleKey) = resolveLocale
+    }
+    if (!request.contains(MessagesKey)) {
+      request(MessagesKey) = provideMessages(locale)
+    }
   }
 
   def locale(implicit request: HttpServletRequest): Locale = {


### PR DESCRIPTION
If there are many ScalatraFilters which extends I18nSupport, the before action of I18nSupport is executed  many times and it causes continuous GC and serious performance issue.

This pull request fixes this to execute the before action of I18nSupport only once per a request.