### PR TITLE
removed crosspaths.sbt

### DIFF
--- a/crosspaths.sbt
+++ b/crosspaths.sbt
@@ -1,1 +1,0 @@
-crossPaths in ThisBuild := true


### PR DESCRIPTION
Although the value has been changed to true with the following commit,
since the default value of crosspaths is true, crosspaths.sbt itself
is considered unnecessary at present.

https://github.com/scalatra/scalatra/commit/3ac6d31f06d55c70ff2e2335153baf94ff62c6b4