### PR TITLE
Add helpers to render forms in Scalate templates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,10 +132,7 @@ lazy val scalatraScalate = Project(
     libraryDependencies += scalate,
     description := "Scalate integration with Scalatra"
   )
-) dependsOn(
-  scalatraCore  % "compile;test->test;provided->provided",
-  scalatraForms % "compile;test->test;provided->provided"
-)
+) dependsOn(scalatraCore  % "compile;test->test;provided->provided")
 
 lazy val scalatraJson = Project(
   id = "scalatra-json",

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,10 @@ lazy val scalatraScalate = Project(
     libraryDependencies += scalate,
     description := "Scalate integration with Scalatra"
   )
-) dependsOn(scalatraCore % "compile;test->test;provided->provided")
+) dependsOn(
+  scalatraCore  % "compile;test->test;provided->provided",
+  scalatraForms % "compile;test->test;provided->provided"
+)
 
 lazy val scalatraJson = Project(
   id = "scalatra-json",

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalatraFormsHelpers.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalatraFormsHelpers.scala
@@ -1,20 +1,101 @@
 package org.scalatra.scalate
 
 import org.fusesource.scalate.servlet.ServletRenderContext
-import org.scalatra.forms
+import org.scalatra.MultiParams
 
 /**
  * Supplies helper methods to render forms in Scalate templates.
  */
 trait ScalatraFormsHelpers { self: ServletRenderContext =>
 
-  def text(name: String, attributes: (String, String)*): Unit = unescape(forms.views.text(name, attributes: _*)(request))
-  def password(name: String, attributes: (String, String)*): Unit = unescape(forms.views.password(name, attributes: _*)(request))
-  def textarea(name: String, attributes: (String, String)*): Unit = unescape(forms.views.textarea(name, attributes: _*)(request))
-  def checkbox(name: String, value: String, attributes: (String, String)*): Unit = unescape(forms.views.checkbox(name, value, attributes: _*)(request))
-  def radio(name: String, value: String, attributes: (String, String)*): Unit = unescape(forms.views.radio(name, value, attributes: _*)(request))
-  def select(name: String, values: Seq[(String, String)], multiple: Boolean, attributes: (String, String)*): Unit = unescape(forms.views.select(name, values, multiple, attributes: _*)(request))
-  def error(name: String): Option[String] = forms.views.error(name)(request)
-  def errors(name: String): Seq[String] = forms.views.errors(name)(request)
+  private val RequestAttributeParamsKey = "org.scalatra.forms.params"
+  private val RequestAttributeErrorsKey = "org.scalatra.forms.errors"
 
+  /**
+   * Render a text field.
+   */
+  def text(name: String, attributes: (String, String)*): Unit = {
+    unescape(s"""<input type="text" name="${escape(name)}" value="${escape(param(name))}" ${attrs(attributes: _*)}>""")
+  }
+
+  /**
+   * Render a password field.
+   */
+  def password(name: String, attributes: (String, String)*): Unit = {
+    unescape(s"""<input type="password" name="${escape(name)}" ${attrs(attributes: _*)}>""")
+  }
+
+  /**
+   * Render a textarea.
+   */
+  def textarea(name: String, attributes: (String, String)*): Unit = {
+    unescape(s"""<textarea name="${escape(name)}" ${attrs(attributes: _*)}>${escape(param(name))}</textarea>""")
+  }
+
+  /**
+   * Render a checkbox.
+   */
+  def checkbox(name: String, value: String, attributes: (String, String)*): Unit = {
+    val checked = if (params(name).contains(value)) "checked" else ""
+    unescape(s"""<input type="checkbox" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>""")
+  }
+
+  /**
+   * Render a radio button.
+   */
+  def radio(name: String, value: String, attributes: (String, String)*): Unit = {
+    val checked = if (param(name) == value) "checked" else ""
+    unescape(s"""<input type="radio" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>""")
+  }
+
+  /**
+   * Render a select box.
+   */
+  def select(name: String, values: Seq[(String, String)], multiple: Boolean, attributes: (String, String)*): Unit = {
+    val sb = new StringBuilder()
+    sb.append(s"""<select name="${escape(name)}" ${if (multiple) "multiple" else ""}>""")
+    values.foreach {
+      case (value, label) =>
+        val selected = if (params(name).contains(value)) "selected" else ""
+        sb.append(s"""<option value="${escape(value)}" $selected>${escape(label)}</option>""")
+    }
+    sb.append("</select>")
+    unescape(sb.toString)
+  }
+
+  /**
+   * Retrieve an error message of the specified field.
+   */
+  def error(name: String): Option[String] = {
+    Option(request.getAttribute(RequestAttributeErrorsKey)).flatMap { errors =>
+      errors.asInstanceOf[Seq[(String, String)]].find(_._1 == name).map(_._2)
+    }
+  }
+
+  /**
+   * Retrieve all error messages of the specified field.
+   */
+  def errors(name: String): Seq[String] = {
+    Option(request.getAttribute(RequestAttributeErrorsKey)).map { errors =>
+      errors.asInstanceOf[Seq[(String, String)]].collect { case error if error._1 == name => error._2 }
+    }.getOrElse(Nil)
+  }
+
+  private def escape(value: String): String = {
+    value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+  }
+
+  private def params(name: String): Seq[String] = {
+    Option(request.getAttribute(RequestAttributeParamsKey)).flatMap { params =>
+      params.asInstanceOf[MultiParams].get(name)
+    }.getOrElse(Nil)
+  }
+
+  private def param(name: String): String = {
+    params(name).headOption.getOrElse("")
+  }
+
+  private def attrs(attrs: (String, String)*): String = {
+    attrs.map { case (name, value) => s"""${escape(name)}="${escape(value)}"""" }.mkString(" ")
+  }
 }

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalatraFormsHelpers.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalatraFormsHelpers.scala
@@ -1,0 +1,20 @@
+package org.scalatra.scalate
+
+import org.fusesource.scalate.servlet.ServletRenderContext
+import org.scalatra.forms
+
+/**
+ * Supplies helper methods to render forms in Scalate templates.
+ */
+trait ScalatraFormsHelpers { self: ServletRenderContext =>
+
+  def text(name: String, attributes: (String, String)*): Unit = unescape(forms.views.text(name, attributes: _*)(request))
+  def password(name: String, attributes: (String, String)*): Unit = unescape(forms.views.password(name, attributes: _*)(request))
+  def textarea(name: String, attributes: (String, String)*): Unit = unescape(forms.views.textarea(name, attributes: _*)(request))
+  def checkbox(name: String, value: String, attributes: (String, String)*): Unit = unescape(forms.views.checkbox(name, value, attributes: _*)(request))
+  def radio(name: String, value: String, attributes: (String, String)*): Unit = unescape(forms.views.radio(name, value, attributes: _*)(request))
+  def select(name: String, values: Seq[(String, String)], multiple: Boolean, attributes: (String, String)*): Unit = unescape(forms.views.select(name, values, multiple, attributes: _*)(request))
+  def error(name: String): Option[String] = forms.views.error(name)(request)
+  def errors(name: String): Seq[String] = forms.views.errors(name)(request)
+
+}

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalatraRenderContext.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalatraRenderContext.scala
@@ -17,7 +17,7 @@ class ScalatraRenderContext(
   engine: TemplateEngine,
   out: PrintWriter,
   req: HttpServletRequest,
-  res: HttpServletResponse) extends ServletRenderContext(engine, out, req, res, kernel.servletContext) {
+  res: HttpServletResponse) extends ServletRenderContext(engine, out, req, res, kernel.servletContext) with ScalatraFormsHelpers {
 
   def flash: scala.collection.Map[String, Any] = kernel match {
     case flashMapSupport: FlashMapSupport => flashMapSupport.flash(request)


### PR DESCRIPTION
Offers better integration with scalate templates and scalatra-forms. These helpers make possiblr to render forms and errors in Scalate templates easily.

An example project is here (This example will be moved to scalatra-website-example):
https://github.com/takezoe/scalatra-forms-scalate

