### PR TITLE
Added parenthesis

### DIFF
--- a/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
+++ b/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
@@ -154,7 +154,7 @@ class AtmosphereSpec extends MutableScalatraSpec {
 
   }
 
-  private def stopSystem: Unit = {
+  private def stopSystem(): Unit = {
     val f = system.terminate()
     Await.result(f, Duration(1, TimeUnit.MINUTES))
   }


### PR DESCRIPTION
remove blow warning

"side-effecting nullary methods are discouraged: suggest defining as `def stopSystem()` instead"