### PR TITLE
Deleted unnecessary code

### DIFF
--- a/json/src/main/scala/org/scalatra/json/Jackson.scala
+++ b/json/src/main/scala/org/scalatra/json/Jackson.scala
@@ -14,15 +14,6 @@ trait JacksonJsonSupport extends JsonSupport[JValue] with JacksonJsonOutput with
     mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, jsonFormats.wantsBigDecimal)
   }
 
-  protected def readJsonFromStreamWithCharset(stream: InputStream, charset: String): JValue = {
-    val rdr = new InputStreamReader(stream, charset)
-    if (rdr.ready()) mapper.readValue(rdr, classOf[JValue])
-    else {
-      rdr.close()
-      JNothing
-    }
-  }
-
   protected def readJsonFromBody(bd: String): JValue = {
     if (bd.nonBlank) mapper.readValue(bd, classOf[JValue])
     else JNothing

--- a/json/src/main/scala/org/scalatra/json/NativeJson.scala
+++ b/json/src/main/scala/org/scalatra/json/NativeJson.scala
@@ -8,15 +8,6 @@ import native._
 import org.scalatra.util.RicherString._
 
 trait NativeJsonSupport extends JsonSupport[Document] with NativeJsonOutput with JValueResult {
-  protected def readJsonFromStreamWithCharset(stream: InputStream, charset: String): JValue = {
-    val rdr = new InputStreamReader(stream, charset)
-    if (rdr.ready()) native.JsonParser.parse(rdr, jsonFormats.wantsBigDecimal)
-    else {
-      rdr.close()
-      JNothing
-    }
-  }
-
   protected def readJsonFromBody(bd: String): JValue = {
     if (bd.nonBlank) native.JsonParser.parse(bd, jsonFormats.wantsBigDecimal)
     else JNothing


### PR DESCRIPTION
JsonSupport.scala's `cacheRequestBodyAsString` method has been
fixed so that it always returns true.
Therefore, it does not pass through the route which becomes false.
Perform refactoring to delete the code related to the route that
becomes false.