### PR TITLE
use body method to read the body of the request

### DIFF
--- a/json/src/main/scala/org/scalatra/json/Jackson.scala
+++ b/json/src/main/scala/org/scalatra/json/Jackson.scala
@@ -14,15 +14,6 @@ trait JacksonJsonSupport extends JsonSupport[JValue] with JacksonJsonOutput with
     mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, jsonFormats.wantsBigDecimal)
   }
 
-  protected def readJsonFromStreamWithCharset(stream: InputStream, charset: String): JValue = {
-    val rdr = new InputStreamReader(stream, charset)
-    if (rdr.ready()) mapper.readValue(rdr, classOf[JValue])
-    else {
-      rdr.close()
-      JNothing
-    }
-  }
-
   protected def readJsonFromBody(bd: String): JValue = {
     if (bd.nonBlank) mapper.readValue(bd, classOf[JValue])
     else JNothing

--- a/json/src/main/scala/org/scalatra/json/NativeJson.scala
+++ b/json/src/main/scala/org/scalatra/json/NativeJson.scala
@@ -8,15 +8,6 @@ import native._
 import org.scalatra.util.RicherString._
 
 trait NativeJsonSupport extends JsonSupport[Document] with NativeJsonOutput with JValueResult {
-  protected def readJsonFromStreamWithCharset(stream: InputStream, charset: String): JValue = {
-    val rdr = new InputStreamReader(stream, charset)
-    if (rdr.ready()) native.JsonParser.parse(rdr, jsonFormats.wantsBigDecimal)
-    else {
-      rdr.close()
-      JNothing
-    }
-  }
-
   protected def readJsonFromBody(bd: String): JValue = {
     if (bd.nonBlank) native.JsonParser.parse(bd, jsonFormats.wantsBigDecimal)
     else JNothing


### PR DESCRIPTION
With the following commit, it was changed to read the cached contents with
the body method rather than reading the body part independently from inputStream.

https://github.com/scalatra/scalatra/commit/a9f092ca69295eb87a9bd7247ca3730bc552c46c

Once inputStream is consumed once, it can not be read again, so the acquisition
of the body part will be unified with the body method of the request object.

The body method of the request object considers the body of JSON type,
and guarantees that it is called multiple times.