### PR TITLE
Fixed to explicitly use tuples

### DIFF
--- a/core/src/test/scala/org/scalatra/ContentTypeTest.scala
+++ b/core/src/test/scala/org/scalatra/ContentTypeTest.scala
@@ -142,7 +142,7 @@ class ContentTypeTest extends ScalatraFunSuite with BeforeAndAfterAll {
       def receive = {
         case i: Int =>
           val res = get("/concurrent/" + i) { response }
-          sender ! (i, res.mediaType)
+          sender ! Tuple(i, res.mediaType)
       }
     }
 


### PR DESCRIPTION
A warning message is issued if it is a tuple, parenthesis of
argument passing or unclear, so declare that it is explicitly
a tuple.