### PR TITLE
Solve outer reference warning

### DIFF
--- a/core/src/test/scala/org/scalatra/ErrorHandlerTest.scala
+++ b/core/src/test/scala/org/scalatra/ErrorHandlerTest.scala
@@ -2,19 +2,21 @@ package org.scalatra
 
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
-class ErrorHandlerTest extends ScalatraFunSuite {
-  trait TestException extends RuntimeException
-  case class Exception1() extends TestException
-  case class Exception2() extends TestException
-  case class Exception3() extends TestException
+trait TestException extends RuntimeException
+case class Exception1() extends TestException
+case class Exception2() extends TestException
+case class Exception3() extends TestException
 
+class ErrorHandlerTest extends ScalatraFunSuite {
   class BaseServlet extends ScalatraServlet {
     get("/1") {
       status = 418
       throw new Exception1
     }
     get("/uncaught") { throw new RuntimeException }
-    error { case e: TestException => "base" }
+    error {
+      case e: TestException => "base"
+    }
   }
 
   class ChildServlet extends BaseServlet {

--- a/core/src/test/scala/org/scalatra/StatusCodeHandlerTest.scala
+++ b/core/src/test/scala/org/scalatra/StatusCodeHandlerTest.scala
@@ -4,12 +4,6 @@ import org.scalatra.test.scalatest.ScalatraFunSuite
 
 class StatusCodeHandlerTest extends ScalatraFunSuite {
 
-  trait TestException extends RuntimeException
-
-  case class Exception1() extends TestException
-
-  case class Exception2() extends TestException
-
   class BaseServlet extends ScalatraServlet {
     get("/401") {
       status = 401


### PR DESCRIPTION
When defined as an inner class, a warning message `The outer reference
in this type test can not be checked at run time .` is outputted, but
because there is no need to be an inner class, we changed the definition
location.

In addition, deleted unnecessary error classes.