### PR TITLE
Set DefaultMultipartConfig

### DIFF
--- a/core/src/test/scala/org/scalatra/servlet/FileUploadSupportSpec.scala
+++ b/core/src/test/scala/org/scalatra/servlet/FileUploadSupportSpec.scala
@@ -8,6 +8,8 @@ import org.scalatra.test.specs2.MutableScalatraSpec
 import scala.collection.JavaConverters._
 
 class FileUploadSupportSpecServlet extends ScalatraServlet with FileUploadSupport {
+  configureMultipartHandling(HasMultipartConfig.DefaultMultipartConfig)
+
   def headersToHeaders(): Unit = {
     request.getHeaderNames.asScala.filter(_.startsWith("X")).foreach(header =>
       response.setHeader(header, request.getHeader(header)))

--- a/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
+++ b/core/src/test/scala/org/scalatra/servlet/FileUploadTestHelpersTest.scala
@@ -8,6 +8,8 @@ import org.scalatra.test.scalatest.ScalatraFunSuite
 import scala.collection.JavaConverters._
 
 class FileUploadTestHelpersTestServlet extends ScalatraServlet with FileUploadSupport {
+  configureMultipartHandling(HasMultipartConfig.DefaultMultipartConfig)
+
   def handleRequest(): Unit = {
     response.setHeader("Request-Method", request.getMethod)
     params.foreach(p => response.setHeader("Param-" + p._1, p._2))


### PR DESCRIPTION
Changes to suppress output of the following message
in FileUploadSupport test

`Couldn't get the multipart config from the servlet context`