### PR TITLE
Set the `FEATURE_SECURE_PROCESSING` flag on the XML parser to avoid resolving external DTDs

### DIFF
--- a/json/src/main/scala/org/scalatra/json/JsonSupport.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonSupport.scala
@@ -3,6 +3,7 @@ package json
 
 import java.io.{ InputStream, InputStreamReader }
 import javax.servlet.http.HttpServletRequest
+import javax.xml.XMLConstants
 
 import org.json4s.Xml._
 import org.json4s._
@@ -57,6 +58,7 @@ trait JsonSupport[T] extends JsonOutput[T] {
   def secureXML: XMLLoader[Elem] = {
     val parserFactory = SAXParserFactory.newInstance()
     parserFactory.setNamespaceAware(false)
+    parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
     parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     val saxParser = parserFactory.newSAXParser()


### PR DESCRIPTION
It was noticed that when posting XML to a Scalatra route that had JSON support, if the XML contains reference to external DTDs the parser will issue a request to the specified URL to download it. This is considered unsafe for many reasons. Setting the `FEATURE_SECURE_PROCESSING` feature on the parser fixes that problem.

I didn't add any test since I don't really know how to test it - here I'm using Wireshark to check outgoing requests.