### PR TITLE
Change the visibility of HaltException and PassException to public

### DIFF
--- a/core/src/main/scala/org/scalatra/Control.scala
+++ b/core/src/main/scala/org/scalatra/Control.scala
@@ -36,12 +36,12 @@ trait Control {
   def pass(): Nothing = throw new PassException
 }
 
-private[scalatra] case class HaltException(
+case class HaltException(
   status: Option[Int],
   headers: Map[String, String],
   body: Any)
   extends Throwable with NoStackTrace
 
-private[scalatra] class PassException
+class PassException
   extends Throwable
   with NoStackTrace


### PR DESCRIPTION
Change the visibility of `HaltException` and `PassException` to public to make the exception handling extensible. 

For example, `ScalatraBase.renderHaltException()` which renders the response for `HaltException` is protected, but actually we can't extend this method because `HaltException` which is passed as an argument is package private for the `org.scalatra` package.

This pull request makes possible to be extensible these methods by changing the visibility of some classes.