### PR TITLE
retain order of paths in swagger 2.0

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -7,6 +7,8 @@ import org.scalatra.json.JsonSupport
 import org.scalatra.swagger.DataType.{ ContainerDataType, ValueDataType }
 import org.slf4j.LoggerFactory
 
+import scala.collection.immutable.ListMap
+
 /**
  * Trait that serves the resource and operation listings, as specified by the Swagger specification.
  */
@@ -96,7 +98,7 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
             ("name" -> swagger.apiInfo.license.name) ~
             ("url" -> swagger.apiInfo.license.url)))) ~
             ("paths" ->
-              (docs.filter(_.apis.nonEmpty).flatMap { doc =>
+              ListMap(docs.filter(_.apis.nonEmpty).flatMap { doc =>
                 doc.apis.collect {
                   case api: SwaggerEndpoint[_] =>
                     (api.path -> api.operations.map { operation =>
@@ -141,9 +143,9 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                                 case _ => (requirement -> List.empty)
                               }
                             }))))
-                    }.toMap)
-                }.toMap
-              }.toMap)) ~
+                    })
+                }
+              }: _*)) ~
               ("definitions" -> docs.flatMap { doc =>
                 doc.models.map {
                   case (name, model) =>


### PR DESCRIPTION
current order of paths in swagger.json

```
/store/order
/pet/findByTags
/store/order/{orderId}
/user/
/pet/{petId}
/pet/findByStatus
/pet/
```

after merged order of paths in swagger.json

```
/store/order
/store/order/{orderId}
/user/
/pet/
/pet/findByStatus
/pet/findByTags
/pet/{petId}
```

I hope to merge this pr into 2.6.x too