### PR TITLE
fix deprecation warning

### DIFF
--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -108,9 +108,11 @@ trait ApiFormats extends ScalatraBase {
     response.contentType flatMap (ctt => ctt.split(";").headOption flatMap mimeTypes.get)
   }
 
+  private[this] val validRange: Set[Double] =
+    Set(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+
   private def parseAcceptHeader(implicit request: HttpServletRequest): List[String] = {
     def isValidQPair(a: Array[String]) = {
-      val validRange = Range.Double.inclusive(0, 1, 0.1)
       a.length == 2 && a(0) == "q" && validRange.contains(a(1).toDouble)
     }
 


### PR DESCRIPTION
https://github.com/scala/scala/pull/6550

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> Range.Double.inclusive(0, 1, 0.1)
<console>:12: warning: method inclusive in object Double is deprecated (since 2.12.6): use Range.BigDecimal.inclusive instead
       Range.Double.inclusive(0, 1, 0.1)
                    ^
res0: scala.collection.immutable.NumericRange[Double] = NumericRange 0.0 to 1.0 by 0.1 (using NumericRange 0.0 to 1.0 by 0.1 of BigDecimal)

scala> res0.toList
res1: List[Double] = List(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
```