### PR TITLE
Fixed not to get JSON data from parameters

### DIFF
--- a/json/src/main/scala/org/scalatra/json/JsonSupport.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonSupport.scala
@@ -25,18 +25,11 @@ trait JsonSupport[T] extends JsonOutput[T] {
   private[this] val logger = LoggerFactory.getLogger(getClass)
 
   protected def parseRequestBody(format: String)(implicit request: HttpServletRequest) = try {
-    val ct = request.contentType getOrElse ""
     if (format == "json") {
-      val bd = {
-        if (ct == "application/x-www-form-urlencoded") multiParams.keys.headOption map readJsonFromBody getOrElse JNothing
-        else readJsonFromBody(request.body)
-      }
+      val bd = readJsonFromBody(request.body)
       transformRequestBody(bd)
     } else if (format == "xml") {
-      val bd = {
-        if (ct == "application/x-www-form-urlencoded") multiParams.keys.headOption map readXmlFromBody getOrElse JNothing
-        else readXmlFromBody(request.body)
-      }
+      val bd = readXmlFromBody(request.body)
       transformRequestBody(bd)
     } else JNothing
   } catch {


### PR DESCRIPTION
When the Content-Type is 'application/x-www-form-urlencoded',
the data of the body part is set as the parameter of the Sevlet
specification.

When Content-Type is 'application/x-www-form-urlencoded', there
is prepared a code which obtains JSON data from parameters, but
in the first place there is a code whose Content-Type is "json"
This conditional branch will never be true as it will not be
reached at the time of "xml".