### PR TITLE
Deleted conditional branch for form data

### DIFF
--- a/json/src/main/scala/org/scalatra/json/JsonSupport.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonSupport.scala
@@ -25,19 +25,10 @@ trait JsonSupport[T] extends JsonOutput[T] {
   private[this] val logger = LoggerFactory.getLogger(getClass)
 
   protected def parseRequestBody(format: String)(implicit request: HttpServletRequest) = try {
-    val ct = request.contentType getOrElse ""
     if (format == "json") {
-      val bd = {
-        if (ct == "application/x-www-form-urlencoded") multiParams.keys.headOption map readJsonFromBody getOrElse JNothing
-        else readJsonFromBody(request.body)
-      }
-      transformRequestBody(bd)
+      transformRequestBody(readJsonFromBody(request.body))
     } else if (format == "xml") {
-      val bd = {
-        if (ct == "application/x-www-form-urlencoded") multiParams.keys.headOption map readXmlFromBody getOrElse JNothing
-        else readXmlFromBody(request.body)
-      }
-      transformRequestBody(bd)
+      transformRequestBody(readXmlFromBody(request.body))
     } else JNothing
   } catch {
     case t: Throwable ⇒ {

--- a/json/src/test/scala/org/scalatra/json/JsonRequestBodySpec.scala
+++ b/json/src/test/scala/org/scalatra/json/JsonRequestBodySpec.scala
@@ -63,6 +63,13 @@ trait JsonRequestSpec extends MutableScalatraSpec {
       }
     }
 
+    "don't parse when content-type is 'application/x-www-form-urlencoded'" in {
+      val rbody = """{"name": "hello world"}"""
+      post("/json", headers = Map("Accept" -> "application/json", "Content-Type" -> "application/x-www-form-urlencoded"), body = rbody) {
+        status must_== 400
+        body must_== "invalid json"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
If the Content-Type is 'application/x-www-form-urlencoded', there
is prepared a code to convert from the parameter to JSON AST, but
only if the Content-Type is 'json' or 'xml' Since it is a route
that is not executed, it will never be true.