### PR TITLE
deprecated JsonValueReader

### DIFF
--- a/json/src/main/scala/org/scalatra/json/Jackson.scala
+++ b/json/src/main/scala/org/scalatra/json/Jackson.scala
@@ -20,6 +20,7 @@ trait JacksonJsonSupport extends JsonSupport[JValue] with JacksonJsonOutput with
   }
 }
 
+@deprecated("JacksonJsonValueReaderProperty is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please use the query syntax of Json4s.", "2.7.0")
 trait JacksonJsonValueReaderProperty extends JsonValueReaderProperty[JValue] { self: jackson.JsonMethods => }
 
 trait JacksonJsonOutput extends JsonOutput[JValue] with jackson.JsonMethods {

--- a/json/src/main/scala/org/scalatra/json/JsonValueReader.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonValueReader.scala
@@ -12,7 +12,6 @@ object JsonValueReader {
   private val separatorEnd = ""
 }
 
-@deprecated("JsonValueReader is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please use the query syntax of Json4s.", "2.7.0")
 class JsonValueReader(val data: JValue)(implicit formats: Formats) extends ValueReader[JValue, JValue] {
   //  type I = T
   import JsonValueReader._

--- a/json/src/main/scala/org/scalatra/json/JsonValueReader.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonValueReader.scala
@@ -12,6 +12,7 @@ object JsonValueReader {
   private val separatorEnd = ""
 }
 
+@deprecated("JsonValueReader is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please use the query syntax of Json4s.", "2.7.0")
 class JsonValueReader(val data: JValue)(implicit formats: Formats) extends ValueReader[JValue, JValue] {
   //  type I = T
   import JsonValueReader._

--- a/json/src/main/scala/org/scalatra/json/NativeJson.scala
+++ b/json/src/main/scala/org/scalatra/json/NativeJson.scala
@@ -14,6 +14,7 @@ trait NativeJsonSupport extends JsonSupport[Document] with NativeJsonOutput with
   }
 }
 
+@deprecated("NativeJsonValueReaderProperty is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please use the query syntax of Json4s.", "2.7.0")
 trait NativeJsonValueReaderProperty extends JsonValueReaderProperty[Document] { self: native.JsonMethods => }
 
 trait NativeJsonOutput extends JsonOutput[Document] with native.JsonMethods {


### PR DESCRIPTION
Because it can be substituted by Json4's query syntax.

Also, since there is no document or test, the purpose of use is unclear.