### PR TITLE
deterred the premature JSON parse

### DIFF
--- a/json/src/main/scala/org/scalatra/json/JsonSupport.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonSupport.scala
@@ -64,21 +64,8 @@ trait JsonSupport[T] extends JsonOutput[T] {
       jv
     } else JNothing
   }
+
   protected def transformRequestBody(body: JValue) = body
-
-  override protected def invoke(matchedRoute: MatchedRoute) = {
-    withRouteMultiParams(Some(matchedRoute)) {
-      val mt = request.contentType.fold("application/x-www-form-urlencoded")(_.split(";").head)
-      val fmt = mimeTypes.getOrElse(mt, "html")
-      if (shouldParseBody(fmt)) {
-        request(ParsedBodyKey) = parseRequestBody(fmt).asInstanceOf[AnyRef]
-      }
-      super.invoke(matchedRoute)
-    }
-  }
-
-  protected def shouldParseBody(fmt: String)(implicit request: HttpServletRequest) =
-    (fmt == "json" || fmt == "xml") && !request.requestMethod.isSafe && parsedBody == JNothing
 
   def parsedBody(implicit request: HttpServletRequest): JValue = request.get(ParsedBodyKey).fold({
     val fmt = requestFormat


### PR DESCRIPTION
In the 'invoke' method, it is judged whether or not parsing is
necessary with the 'shouldParseBody' method, but since you are
calling 'parsedBody' in the 'shouldParseBody' method in the
first place, if you mix-in 'JsonSupport', every time an action
is executed, JSON's Parsing necessity judgment and execution of
parsing itself are done.

This should be executed explicitly in the action.