### PR TITLE
Improved discrimination of mime type

### DIFF
--- a/core/src/main/scala/org/scalatra/util/Mimes.scala
+++ b/core/src/main/scala/org/scalatra/util/Mimes.scala
@@ -59,18 +59,6 @@ trait Mimes {
   }
 
   /**
-   * Detects the mime type of a given file path.
-   *
-   * @param path The path for which to detect the mime type
-   * @param fallback A fallback value in case no mime type can be found
-   */
-  def mimeType(path: String, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(path, new MimeType(fallback))).toString
-    }
-  }
-
-  /**
    * Detects the mime type of a given url.
    *
    * @param url The url for which to detect the mime type

--- a/core/src/main/scala/org/scalatra/util/Mimes.scala
+++ b/core/src/main/scala/org/scalatra/util/Mimes.scala
@@ -1,7 +1,7 @@
 package org.scalatra.util
 
 import java.io.{ File, InputStream }
-import java.net.{ URI, URL }
+import java.net.{ URI, URL, URLConnection }
 
 import eu.medsea.mimeutil.{ MimeType, MimeUtil2 }
 import eu.medsea.util.EncodingGuesser
@@ -47,11 +47,12 @@ trait Mimes {
       MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(content, new MimeType(fallback))).toString
     }
   }
+
   def fileMime(file: File, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(file, new MimeType(fallback))).toString
-    }
+    val mimeType = URLConnection.guessContentTypeFromName(file.getName)
+    if (mimeType != null) mimeType else fallback
   }
+
   def inputStreamMime(input: InputStream, fallback: String = DefaultMime): String = {
     detectMime(fallback) {
       MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(input, new MimeType(fallback))).toString

--- a/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
@@ -1,5 +1,6 @@
 package org.scalatra
 
+import java.io.File
 import java.io.ByteArrayOutputStream
 
 import org.scalatra.test.specs2.MutableScalatraSpec
@@ -30,6 +31,12 @@ trait ActionResultTestBase {
 
   get("/bytes") {
     Ok("Hello, world!".getBytes)
+  }
+
+  get("/file-png") {
+    val url = getClass.getResource("/org/scalatra/servlet/smiley.png")
+
+    new File(url.toURI)
   }
 
   get("/error") {
@@ -105,6 +112,15 @@ abstract class ActionResultsSpec extends MutableScalatraSpec {
     "infer contentType for Array[Byte]" in {
       get("/bytes") {
         response.getContentType mustEqual "text/plain;charset=" + java.nio.charset.Charset.defaultCharset.displayName.toLowerCase
+      }
+    }
+
+    "infer contentType for File" in {
+      get("/file-png") {
+        // Originally it is unnecessary to specify charset in the png file,
+        // but it matches Scalatra's specification at the present time.
+        // Future revision is necessary.
+        response.getContentType mustEqual "image/png;charset=utf-8"
       }
     }
 


### PR DESCRIPTION
changed the way to guess the MIME Type of a file

Changed to use URLConnection.guessContentTypeFromName
for guessing the MIME Type from the file path.

By doing this, we can add an arbitrary MIME Type by
writing the definition in the file of the path set in
the system property `content.types.user.table`.

Although it is possible to add arbitrary MIME types
even with mime-util which has been used so far, it was
judged that it is easier to understand according to the
method used in the standard library.

Although it needs to be described in the document, since it is not written enough in the document about originally MIME Type guess, it creates another PR again.