### PR TITLE
avoid scala.collection.immutable.DefaultMap

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
@@ -10,7 +10,6 @@ import org.scalatra.util.RicherString._
 import org.scalatra.util.MultiMapHeadView
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.DefaultMap
 import scala.collection.{ Map => CMap }
 import scala.io.Source
 
@@ -113,9 +112,22 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
    * A map of headers.  Multiple header values are separated by a ','
    * character.  The keys of this map are case-insensitive.
    */
-  object headers extends DefaultMap[String, String] {
+  object headers extends collection.immutable.Map[String, String] {
 
     def get(name: String): Option[String] = Option(r.getHeader(name))
+
+    override def +[V1 >: String](kv: (String, V1)): Map[String, V1] = {
+      val b = Map.newBuilder[String, V1]
+      b ++= this
+      b += ((kv._1, kv._2))
+      b.result()
+    }
+
+    override def -(key: String): Map[String, String] = {
+      val b = this.newBuilder
+      for (kv <- this; if kv._1 != key) b += kv
+      b.result()
+    }
 
     private[scalatra] def getMulti(key: String): Seq[String] = {
       get(key).map(_.split(",").toSeq.map(_.trim)).getOrElse(Seq.empty)

--- a/core/src/main/scala/org/scalatra/servlet/ServletBase.scala
+++ b/core/src/main/scala/org/scalatra/servlet/ServletBase.scala
@@ -6,7 +6,6 @@ import javax.servlet.ServletContext
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.DefaultMap
 
 /**
  * ServletBase implements the Scalatra DSL with the Servlet API, and can be
@@ -31,9 +30,22 @@ trait ServletBase
 
     override def context: ServletContext = config.getServletContext
 
-    object initParameters extends DefaultMap[String, String] {
+    object initParameters extends collection.immutable.Map[String, String] {
 
       override def get(key: String): Option[String] = Option(config.getInitParameter(key))
+
+      override def +[V1 >: String](kv: (String, V1)): Map[String, V1] = {
+        val b = Map.newBuilder[String, V1]
+        b ++= this
+        b += ((kv._1, kv._2))
+        b.result()
+      }
+
+      override def -(key: String): Map[String, String] = {
+        val b = this.newBuilder
+        for (kv <- this; if kv._1 != key) b += kv
+        b.result()
+      }
 
       override def iterator: Iterator[(String, String)] = {
         for (name <- config.getInitParameterNames.asScala)

--- a/test/src/main/scala/org/scalatra/test/ClientResponse.scala
+++ b/test/src/main/scala/org/scalatra/test/ClientResponse.scala
@@ -2,8 +2,6 @@ package org.scalatra.test
 
 import java.io.InputStream
 
-import scala.collection.DefaultMap
-
 case class ResponseStatus(code: Int, message: String)
 
 import scala.collection.JavaConverters._
@@ -25,12 +23,26 @@ abstract class ClientResponse {
 
   def status = statusLine.code
 
-  val header = new DefaultMap[String, String] {
+  val header: Map[String, String] = new Map[String, String] {
+
     def get(key: String) = {
       headers.get(key) match {
         case Some(values) => Some(values.head)
         case _ => None
       }
+    }
+
+    override def +[V1 >: String](kv: (String, V1)): Map[String, V1] = {
+      val b = Map.newBuilder[String, V1]
+      b ++= this
+      b += ((kv._1, kv._2))
+      b.result()
+    }
+
+    override def -(key: String): Map[String, String] = {
+      val b = this.newBuilder
+      for (kv <- this; if kv._1 != key) b += kv
+      b.result()
     }
 
     override def apply(key: String) = {


### PR DESCRIPTION
prepare Scala 2.13. `scala.collection.immutable.DefaultMap` removed in Scala 2.13.0-M4

https://github.com/scala/scala/pull/6787