### PR TITLE
Removed dependency on mime-util

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,6 @@ lazy val scalatraCore = Project(
       servletApi % "provided;test",
       slf4jApi,
       jUniversalChardet,
-      mimeUtil,
       commonsLang3,
       parserCombinators,
       xml,

--- a/core/src/main/scala/org/scalatra/util/Mimes.scala
+++ b/core/src/main/scala/org/scalatra/util/Mimes.scala
@@ -1,101 +1,92 @@
 package org.scalatra.util
 
-import java.io.{ File, InputStream }
-import java.net.{ URI, URL }
-
-import eu.medsea.mimeutil.{ MimeType, MimeUtil2 }
-import eu.medsea.util.EncodingGuesser
-import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConverters._
-import scala.util.control.Exception._
+import java.io.{ File, InputStream, ByteArrayInputStream }
+import java.net.{ URI, URLConnection }
 
 object Mimes {
-
   val DefaultMime = "application/octet-stream"
-  /**
-   * Sets supported encodings for the mime-util library if they have not been
-   * set. Since the supported encodings is stored as a static Set we
-   * synchronize access.
-   */
-  private def registerEncodingsIfNotSet(): Unit = {
-    synchronized {
-      if (EncodingGuesser.getSupportedEncodings.isEmpty) {
-        val enc = Set("UTF-8", "ISO-8859-1", "windows-1252", "MacRoman", EncodingGuesser.getDefaultEncoding)
-        EncodingGuesser.setSupportedEncodings(enc.asJava)
-      }
-    }
-  }
-  registerEncodingsIfNotSet
 }
 
 /**
- * A utility to help with mime type detection for a given file path or url
+ * A utility to help with mime type detection for a given file path or url.
  */
+
 trait Mimes {
 
   import org.scalatra.util.Mimes._
 
-  @transient private[this] val internalLogger = LoggerFactory.getLogger(getClass)
-
-  protected[this] def mimeUtil: MimeUtil2 = new MimeUtil2()
-  quiet { mimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.MagicMimeMimeDetector") }
-  quiet { mimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.ExtensionMimeDetector") }
-
+  /**
+   * Detects the mime type of a given Byte array.
+   *
+   * When inappropriate MIME Type can not be inferred,
+   * "text/pain" is returned.
+   *
+   * @param content The Byte array for which to detect the mime type
+   * @param fallback A fallback value in case no mime type can be found
+   */
   def bytesMime(content: Array[Byte], fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(content, new MimeType(fallback))).toString
+    // for backward compatibility...even when it is empty, "text/plain" may be good.
+    if (content.isEmpty == true) {
+      return fallback
     }
-  }
-  def fileMime(file: File, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(file, new MimeType(fallback))).toString
-    }
-  }
-  def inputStreamMime(input: InputStream, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(input, new MimeType(fallback))).toString
-    }
+
+    val is = new ByteArrayInputStream(content)
+    val mimeType = URLConnection.guessContentTypeFromStream(is)
+
+    if (mimeType != null) mimeType else "text/plain"
   }
 
   /**
-   * Detects the mime type of a given file path.
+   * Detects the mime type of a given File.
    *
-   * @param path The path for which to detect the mime type
+   * When inappropriate MIME Type can not be inferred,
+   * "application/octet-stream" is returned.
+   *
+   * This method guesses the MIME type using `java.net.URLConnection.guessContentTypeFromName`.
+   * Therefore, by defining an arbitrary MIME type in the configuration file specified by
+   * the `content.types.user.table` property, an arbitrary MIME type can be guessed.
+   *
+   * @param file The File for which to detect the mime type
    * @param fallback A fallback value in case no mime type can be found
    */
-  def mimeType(path: String, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(mimeUtil.getMimeTypes(path, new MimeType(fallback))).toString
-    }
+  def fileMime(file: File, fallback: String = DefaultMime): String = {
+    val mimeType = URLConnection.guessContentTypeFromName(file.getName)
+
+    if (mimeType != null) mimeType else fallback
+  }
+
+  /**
+   * Detects the mime type of a given InputStream.
+   *
+   * When inappropriate MIME Type can not be inferred,
+   * "application/octet-stream" is returned.
+   *
+   * @param input The InputStream for which to detect the mime type
+   * @param fallback A fallback value in case no mime type can be found
+   */
+  def inputStreamMime(input: InputStream, fallback: String = DefaultMime): String = {
+    val mimeType = URLConnection.guessContentTypeFromStream(input)
+
+    if (mimeType != null) mimeType else fallback
   }
 
   /**
    * Detects the mime type of a given url.
    *
+   * When inappropriate MIME Type can not be inferred,
+   * "application/octet-stream" is returned.
+   *
+   * This method guesses the MIME type using `java.net.URLConnection.guessContentTypeFromName`.
+   * Therefore, by defining an arbitrary MIME type in the configuration file specified by
+   * the `content.types.user.table` property, an arbitrary MIME type can be guessed.
+   *
    * @param url The url for which to detect the mime type
    * @param fallback A fallback value in case no mime type can be found
    */
   def urlMime(url: String, fallback: String = DefaultMime): String = {
-    detectMime(fallback) {
-      MimeUtil2.getMostSpecificMimeType(
-        mimeUtil.getMimeTypes(new URL(url), new MimeType(fallback))).toString
-    }
-  }
+    val mimeType = URLConnection.guessContentTypeFromName(url)
 
-  private def detectMime(fallback: String = DefaultMime)(mimeDetect: => String): String = {
-    def errorHandler(t: Throwable) = {
-      internalLogger.warn("There was an error detecting the mime type. ", t)
-      fallback
-    }
-    allCatch.withApply(errorHandler)(mimeDetect)
-  }
-
-  def isTextMime(mime: String): Boolean = MimeUtil2.isTextMimeType(new MimeType(mime))
-
-  private def quiet(fn: => Unit): Unit = {
-    allCatch.withApply(
-      internalLogger.warn("An error occurred while registering a mime type detector.", _))(fn)
+    if (mimeType != null) mimeType else fallback
   }
 
   def apply(input: InputStream) = inputStreamMime(input)

--- a/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ActionResultsSpec.scala
@@ -1,6 +1,7 @@
 package org.scalatra
 
 import java.io.ByteArrayOutputStream
+import java.io.File
 
 import org.scalatra.test.specs2.MutableScalatraSpec
 
@@ -54,6 +55,12 @@ trait ActionResultTestBase {
   get("/input-stream") {
     contentType = "image/png"
     getClass.getResourceAsStream("/org/scalatra/servlet/smiley.png")
+  }
+
+  get("/file") {
+    val url = getClass.getResource("/org/scalatra/servlet/smiley.png")
+
+    new File(url.toURI)
   }
 
   get("/defaults-to-call-by-value") {
@@ -119,6 +126,10 @@ abstract class ActionResultsSpec extends MutableScalatraSpec {
       get("/input-stream") {
         response.mediaType must beSome("image/png")
         bodyBytes must_== expected
+      }
+
+      get("/file") {
+        response.mediaType must beSome("image/png")
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,6 @@ object Dependencies {
   lazy val junit                    =  "junit"                   %  "junit"                      % "4.12"
   lazy val jUniversalChardet        =  "com.googlecode.juniversalchardet" % "juniversalchardet"  % "1.0.3"
   lazy val logbackClassic           =  "ch.qos.logback"          %  "logback-classic"            % "1.2.3"
-  lazy val mimeUtil                 =  "eu.medsea.mimeutil"      %  "mime-util"                  % "2.1.3" exclude("org.slf4j", "slf4j-log4j12") exclude("log4j", "log4j")
   lazy val mockitoAll               =  "org.mockito"             %  "mockito-core"               % "2.18.3"
   lazy val scalate                  =  "org.scalatra.scalate"    %% "scalate-core"               % scalateVersion
   lazy val scalatest                =  "org.scalatest"           %% "scalatest"                  % scalatestVersion


### PR DESCRIPTION
`MimeTypes` used mime-util to guess the MIME Type, but that
mime-util has not been maintained for a long time and now that
`java.net.URLConnection` can do the same thing.

Although mime-util uses magic.mime, the accuracy of guess is high,
but in generating content-type on the server side, there seems to
be no scenario where this is a problem ... as it becomes a problem,
we can set the content-type explicitly.

Also, mime-util uses extensions for MIME Type guesses, but can not
add any extensions.
`java.net.URLConnection` can add any extension to target.

For the above reason, replace with `java.net.URLConnection`