### PR TITLE
Scalatra Swagger: Add "java.time.Instant" to the list of supported DateTime types (2.7.x)

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -378,7 +378,8 @@ object DataType {
     Set[Class[_]](classOf[java.time.LocalDate])
   private[this] def isDate(klass: Class[_]) = DateTypes.exists(_.isAssignableFrom(klass))
   private[this] val DateTimeTypes =
-    Set[Class[_]](classOf[JDate], classOf[java.time.LocalDateTime], classOf[java.time.ZonedDateTime], classOf[java.time.OffsetDateTime])
+    Set[Class[_]](classOf[JDate], classOf[java.time.LocalDateTime], classOf[java.time.ZonedDateTime], classOf[java.time.OffsetDateTime],
+      classOf[java.time.Instant])
   private[this] def isDateTime(klass: Class[_]) = DateTimeTypes.exists(_.isAssignableFrom(klass))
 
   private[this] def isCollection(klass: Class[_]) =

--- a/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
@@ -24,12 +24,12 @@ class DataTypeSpec extends Specification {
       DataType[java.math.BigInteger] must_== DataType.Int
     }
 
-    "return correct Long datatype" in {
+    "return a correct Long datatype" in {
       DataType[java.lang.Long] must_== DataType.Long
       DataType[Long] must_== DataType.Long
     }
 
-    "return correct Byte datatype" in {
+    "return a correct Byte datatype" in {
       DataType[java.lang.Byte] must_== DataType.Byte
       DataType[Byte] must_== DataType.Byte
     }

--- a/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
@@ -52,6 +52,9 @@ class DataTypeSpec extends Specification {
 
     "return a correct DateTime datatype" in {
       DataType[java.util.Date] must_== DataType.DateTime
+      DataType[java.time.LocalDateTime] must_== DataType.DateTime
+      DataType[java.time.ZonedDateTime] must_== DataType.DateTime
+      DataType[java.time.OffsetDateTime] must_== DataType.DateTime
     }
 
     "return a correct Boolean datatype" in {

--- a/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
@@ -47,6 +47,10 @@ class DataTypeSpec extends Specification {
     }
 
     "return a correct Date datatype" in {
+      DataType[java.time.LocalDate] must_== DataType.Date
+    }
+
+    "return a correct DateTime datatype" in {
       DataType[java.util.Date] must_== DataType.DateTime
     }
 

--- a/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
@@ -55,6 +55,7 @@ class DataTypeSpec extends Specification {
       DataType[java.time.LocalDateTime] must_== DataType.DateTime
       DataType[java.time.ZonedDateTime] must_== DataType.DateTime
       DataType[java.time.OffsetDateTime] must_== DataType.DateTime
+      DataType[java.time.Instant] must_== DataType.DateTime
     }
 
     "return a correct Boolean datatype" in {

--- a/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/DataTypeSpec.scala
@@ -34,14 +34,14 @@ class DataTypeSpec extends Specification {
       DataType[Byte] must_== DataType.Byte
     }
 
-    "return a correct Decimal datatype" in {
+    "return a correct Double datatype" in {
       DataType[java.lang.Double] must_== DataType.Double
       DataType[Double] must_== DataType.Double
       DataType[BigDecimal] must_== DataType.Double
       DataType[java.math.BigDecimal] must_== DataType.Double
     }
 
-    "return a correct Decimal datatype" in {
+    "return a correct Float datatype" in {
       DataType[java.lang.Float] must_== DataType.Float
       DataType[Float] must_== DataType.Float
     }


### PR DESCRIPTION
Almost the same as https://github.com/scalatra/scalatra/pull/869 but into `2.7.x`