### PR TITLE
Update json4s version to 3.6.3 (2.6.x)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,8 @@ lazy val scalatraJson = Project(
     libraryDependencies ++= Seq(
       json4sJackson % "provided",
       json4sNative % "provided",
-      json4sCore
+      json4sCore,
+      json4sXml
     )
   )
 ) dependsOn(scalatraCore % "compile;test->test;provided->provided")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
   lazy val json4sExt                =  "org.json4s"              %% "json4s-ext"                 % json4sVersion
   lazy val json4sJackson            =  "org.json4s"              %% "json4s-jackson"             % json4sVersion
   lazy val json4sNative             =  "org.json4s"              %% "json4s-native"              % json4sVersion
+  lazy val json4sXml                =  "org.json4s"              %% "json4s-xml"                 % json4sVersion
   lazy val junit                    =  "junit"                   %  "junit"                      % "4.12"
   lazy val jUniversalChardet        =  "com.googlecode.juniversalchardet" % "juniversalchardet"  % "1.0.3"
   lazy val logbackClassic           =  "ch.qos.logback"          %  "logback-classic"            % "1.2.3"
@@ -58,7 +59,7 @@ object Dependencies {
   private val atmosphereCompatVersion = "2.0.1"
   private val httpcomponentsVersion   = "4.5.3"
   private val jettyVersion            = "9.4.6.v20170531"
-  private val json4sVersion           = "3.5.2"
+  private val json4sVersion           = "3.6.3"
   private val scalateVersion          = "1.8.0"
   private val scalatestVersion        = "3.0.3"
   private val specs2Version           = "4.0.1"

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSerializers.scala
@@ -43,9 +43,6 @@ object SwaggerSerializers {
 
     private[this] val self = this
 
-    // since 2.4.0: anyway set as false by default
-    val strict: Boolean = false
-
     def withAuthorizationTypeSerializer(serializer: Serializer[AuthorizationType]): SwaggerFormats = new SwaggerFormats {
       override val customSerializers: List[Serializer[_]] = serializer :: SwaggerFormats.serializers
     }
@@ -61,7 +58,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = self.wantsBigDecimal
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def +(extraHints: TypeHints): SwaggerFormats = new SwaggerFormats {
@@ -74,7 +71,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = self.wantsBigDecimal
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def withCompanions(comps: (Class[_], AnyRef)*): SwaggerFormats = new SwaggerFormats {
@@ -87,7 +84,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = self.wantsBigDecimal
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = comps.toList ::: self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def withDouble: SwaggerFormats = new SwaggerFormats {
@@ -100,7 +97,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = false
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def withBigDecimal: SwaggerFormats = new SwaggerFormats {
@@ -113,7 +110,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = true
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def withHints(hints: TypeHints): SwaggerFormats = new SwaggerFormats {
@@ -126,7 +123,7 @@ object SwaggerSerializers {
       override val wantsBigDecimal: Boolean = self.wantsBigDecimal
       override val primitives: Set[Type] = self.primitives
       override val companions: List[(Class[_], AnyRef)] = self.companions
-      override val strict: Boolean = self.strict
+      override val strict: Formats = self.nonStrict
     }
 
     override def lossless: SwaggerFormats = new SwaggerFormats {
@@ -134,7 +131,7 @@ object SwaggerSerializers {
     }
 
     override val customSerializers: List[Serializer[_]] = new AuthorizationTypeSerializer :: SwaggerFormats.serializers
-    override def ++(newSerializers: Traversable[Serializer[_]]): SwaggerFormats = newSerializers.foldLeft(this)(_ + _)
+    override def ++(newSerializers: Iterable[Serializer[_]]): SwaggerFormats = newSerializers.foldLeft(this)(_ + _)
     override def +(newSerializer: Serializer[_]): SwaggerFormats = new SwaggerFormats {
       override val customSerializers: List[Serializer[_]] = newSerializer :: SwaggerFormats.this.customSerializers
     }


### PR DESCRIPTION
Using Scalatra Swagger and new versions of json4s throws `java.lang.NoSuchMethodError: org.json4s.JsonDSL$.seq2jvalue(Lscala/collection/Traversable;Lscala/Function1;)Lorg/json4s/JsonAST$JArray;`

Since seq2jvalue changes Traversable for Iterable on his signature. New versions of json4s brings new serailizers (like JavaTimeSerializers) that are not available on previous versions.