### PR TITLE
Partial backport of Date & Time support for Swagger from 2.7.x branch

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -46,7 +46,22 @@ trait SwaggerEngine[T <: SwaggerApi[_]] {
 
 object Swagger {
 
-  val excludes: Set[java.lang.reflect.Type] = Set(classOf[java.util.TimeZone], classOf[java.util.Date], classOf[DateTime], classOf[LocalDate], classOf[ReadableInstant], classOf[Chronology], classOf[DateTimeZone])
+  val excludes: Set[java.lang.reflect.Type] = Set(
+    classOf[java.util.TimeZone],
+    classOf[java.util.Date],
+    classOf[DateTime],
+    classOf[LocalDate],
+    classOf[ReadableInstant],
+    classOf[Chronology],
+    classOf[DateTimeZone],
+    classOf[java.time.OffsetDateTime],
+    classOf[java.time.ZonedDateTime],
+    classOf[java.time.LocalDateTime],
+    classOf[java.time.LocalDate],
+    classOf[java.time.LocalTime],
+    classOf[java.time.Instant],
+    classOf[java.time.chrono.Chronology],
+    classOf[java.time.ZoneOffset])
   val SpecVersion = "2.0"
 
   def collectModels[T: Manifest](alreadyKnown: Set[Model]): Set[Model] = collectModels(Reflector.scalaTypeOf[T], alreadyKnown)


### PR DESCRIPTION
from https://github.com/scalatra/scalatra/pull/870