### PR TITLE
Deprecated Symbol's access to the Map

### DIFF
--- a/core/src/main/scala/org/scalatra/FlashMap.scala
+++ b/core/src/main/scala/org/scalatra/FlashMap.scala
@@ -3,21 +3,15 @@ package org.scalatra
 import java.util.concurrent.{ ConcurrentHashMap, ConcurrentSkipListSet }
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
-import org.scalatra.util.MutableMapWithIndifferentAccess
-
 import scala.collection.JavaConverters._
 
 /**
  * A FlashMap is the data structure used by [[org.scalatra.FlashMapSupport]]
  * to allow passing temporary values between sequential actions.
  *
- * FlashMap behaves like [[org.scalatra.util.MapWithIndifferentAccess]].  By
- * default, anything placed in the map is available to the current request and
- * next request, and is then discarded.
- *
  * @see FlashMapSupport
  */
-class FlashMap extends MutableMapWithIndifferentAccess[Any] with Serializable {
+class FlashMap extends scala.collection.mutable.Map[String, Any] with Serializable {
 
   private[this] val m = new ConcurrentHashMap[String, Any]().asScala
 

--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -819,8 +819,6 @@ trait ScalatraBase
 
   def params(key: String)(implicit request: HttpServletRequest): String = params(request)(key)
 
-  def params(key: Symbol)(implicit request: HttpServletRequest): String = params(request)(key)
-
   def params(implicit request: HttpServletRequest): Params = new ScalatraParams(multiParams)
 
 }

--- a/core/src/main/scala/org/scalatra/ScalatraParams.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraParams.scala
@@ -1,8 +1,7 @@
 package org.scalatra
 
-import org.scalatra.util.{ MapWithIndifferentAccess, MultiMapHeadView }
+import org.scalatra.util.MultiMapHeadView
 
 class ScalatraParams(
   protected val multiMap: Map[String, Seq[String]])
   extends MultiMapHeadView[String, String]
-  with MapWithIndifferentAccess[String]

--- a/core/src/main/scala/org/scalatra/SessionSupport.scala
+++ b/core/src/main/scala/org/scalatra/SessionSupport.scala
@@ -16,8 +16,6 @@ trait SessionSupport { self: ServletApiImplicits =>
 
   def session(key: String)(implicit request: HttpServletRequest): Any = session(request)(key)
 
-  def session(key: Symbol)(implicit request: HttpServletRequest): Any = session(request)(key)
-
   /**
    * The current session.  If none exists, None is returned.
    */

--- a/core/src/main/scala/org/scalatra/package.scala
+++ b/core/src/main/scala/org/scalatra/package.scala
@@ -1,7 +1,7 @@
 package org
 
 import org.scalatra.servlet.FileUploadSupport
-import org.scalatra.util.{ MapWithIndifferentAccess, MultiMapHeadView }
+import org.scalatra.util.MultiMapHeadView
 
 package object scalatra
   extends Control // make halt and pass visible to helpers outside the DSL
@@ -10,7 +10,7 @@ package object scalatra
 
   type MultiParams = Map[String, Seq[String]]
 
-  type Params = MultiMapHeadView[String, String] with MapWithIndifferentAccess[String]
+  type Params = MultiMapHeadView[String, String]
 
   type Action = () => Any
 

--- a/core/src/main/scala/org/scalatra/servlet/AttributesMap.scala
+++ b/core/src/main/scala/org/scalatra/servlet/AttributesMap.scala
@@ -1,7 +1,6 @@
 package org.scalatra
 package servlet
 
-import org.scalatra.util.MutableMapWithIndifferentAccess
 import org.scalatra.util.conversion.TypeConverter
 
 import scala.collection.JavaConverters._
@@ -11,7 +10,7 @@ import scala.collection.mutable.Map
  * Adapts attributes from servlet objects (e.g., ServletRequest, HttpSession,
  * ServletContext) to a mutable map.
  */
-trait AttributesMap extends Map[String, Any] with MutableMapWithIndifferentAccess[Any] {
+trait AttributesMap extends Map[String, Any] {
 
   protected def attributes: Attributes
 

--- a/core/src/main/scala/org/scalatra/util/MapWithIndifferentAccess.scala
+++ b/core/src/main/scala/org/scalatra/util/MapWithIndifferentAccess.scala
@@ -8,6 +8,8 @@ import scala.collection.Map
  * for maps with arbitrary keys.  There is no performance gain using symbols.  It is here to make our Rubyists feel
  * more at home.
  */
+
+@deprecated("MapWithIndifferentAccess is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please unify the key type of Map to either String or Symbol.", "2.7.0")
 trait MapWithIndifferentAccess[+B] extends Map[String, B] {
 
   def get(key: Symbol): Option[B] = get(key.name)

--- a/core/src/main/scala/org/scalatra/util/MultiMapHeadView.scala
+++ b/core/src/main/scala/org/scalatra/util/MultiMapHeadView.scala
@@ -10,12 +10,6 @@ object MultiMapHeadView {
     }
   }
 
-  def emptyIndifferent[B]: MultiMapHeadView[String, B] with MapWithIndifferentAccess[B] = {
-    new MultiMapHeadView[String, B] with MapWithIndifferentAccess[B] {
-      override protected val multiMap = Map.empty[String, Seq[B]]
-    }
-  }
-
 }
 
 trait MultiMapHeadView[A, B] extends Map[A, B] {

--- a/core/src/main/scala/org/scalatra/util/MutableMapWithIndifferentAccess.scala
+++ b/core/src/main/scala/org/scalatra/util/MutableMapWithIndifferentAccess.scala
@@ -5,6 +5,8 @@ import scala.collection.mutable.Map
 /**
  * @see MapWithIndifferentAccess
  */
+
+@deprecated("MutableMapWithIndifferentAccess is deprecated from Scalatra 2.7.0. It will be deleted in the next major version. Please unify the key type of Map to either String or Symbol.", "2.7.0")
 trait MutableMapWithIndifferentAccess[B]
   extends MapWithIndifferentAccess[B]
   with Map[String, B] {

--- a/core/src/test/scala/org/scalatra/FlashMapTest.scala
+++ b/core/src/test/scala/org/scalatra/FlashMapTest.scala
@@ -122,12 +122,6 @@ class FlashMapTest extends FunSuite with Matchers with BeforeAndAfterEach {
     flash.get("foo") should equal(None)
   }
 
-  test("supports symbols as keys") {
-    flash("foo") = "bar"
-    flash.sweep()
-    flash('foo) should equal("bar")
-  }
-
   test("is serializable") {
     flash("foo") = "bar"
     val out = new ObjectOutputStream(new ByteArrayOutputStream)

--- a/core/src/test/scala/org/scalatra/ParamsExtensionSpec.scala
+++ b/core/src/test/scala/org/scalatra/ParamsExtensionSpec.scala
@@ -4,14 +4,14 @@ import java.text.SimpleDateFormat
 import java.util.Date
 
 import org.scalatra.util.conversion.TypeConverter
-import org.scalatra.util.{ MapWithIndifferentAccess, MultiMapHeadView }
+import org.scalatra.util.MultiMapHeadView
 import org.specs2.mutable.Specification
 
 class ParamsExtensionSpec extends Specification {
 
   import org.scalatra.ScalatraParamsImplicits._
 
-  case class FakeParams(params: Map[String, String]) extends MultiMapHeadView[String, String] with MapWithIndifferentAccess[String] {
+  case class FakeParams(params: Map[String, String]) extends MultiMapHeadView[String, String] {
     protected def multiMap = params.map(e => (e._1, Seq(e._2)))
   }
 

--- a/core/src/test/scala/org/scalatra/ParamsTest.scala
+++ b/core/src/test/scala/org/scalatra/ParamsTest.scala
@@ -29,14 +29,6 @@ class ParamsTestServlet extends ScalatraServlet {
     }
   }
 
-  get("/symbol/:sym") {
-    params('sym)
-  }
-
-  get("/twoSymbols/:sym1/:sym2") {
-    params('sym1) + " and " + params('sym2)
-  }
-
   post("/read-body") {
     "body: " + request.body
   }
@@ -73,18 +65,6 @@ class ParamsTest extends ScalatraFunSuite {
   test("params on unknown key throws NoSuchElementException") {
     get("/params/oops") {
       body should equal(ParamsTestServlet.NoSuchElement)
-    }
-  }
-
-  test("can use symbols as keys for retrieval") {
-    get("/symbol/hello") {
-      body should equal("hello")
-    }
-  }
-
-  test("can use symbols multiple times ") {
-    get("/twoSymbols/hello/world") {
-      body should equal("hello and world")
     }
   }
 

--- a/core/src/test/scala/org/scalatra/SessionTest.scala
+++ b/core/src/test/scala/org/scalatra/SessionTest.scala
@@ -15,13 +15,7 @@ class SessionTestServlet extends ScalatraServlet {
   get("/session-option") {
     sessionOption map { _ => "Some" } getOrElse "None"
   }
-  get("/session-symbol") {
-    session.getOrElse('val, "failure!")
-  }
 
-  post("/session-symbol-update") {
-    session('val) = "set with symbol"
-  }
 }
 
 class SessionTest extends ScalatraFunSuite {
@@ -51,18 +45,6 @@ class SessionTest extends ScalatraFunSuite {
     }
   }
 
-  test("GET /session with the session should return the data set in POST /session even via symbol") {
-    val data = "session_value"
-    session {
-      post("/session", "val" -> data) {
-        body should equal(data)
-      }
-      get("/session-symbol") {
-        body should equal(data)
-      }
-    }
-  }
-
   test("sessionOption should be None when no session exists") {
     session {
       get("/session-option") {
@@ -77,15 +59,6 @@ class SessionTest extends ScalatraFunSuite {
 
       get("/session-option") {
         body should equal("Some")
-      }
-    }
-  }
-
-  test("can update session with symbol") {
-    session {
-      post("/session-symbol-update") {}
-      get("/session-symbol") {
-        body should equal("set with symbol")
       }
     }
   }


### PR DESCRIPTION
In Scala there is no merit in access by Symbol and
it is deprecated in order to eliminate the inheritance
hierarchy of complicated Map.