### PR TITLE
Deleted unnecessary Map inheritance

### DIFF
--- a/common/src/main/scala/org/scalatra/Initializable.scala
+++ b/common/src/main/scala/org/scalatra/Initializable.scala
@@ -12,7 +12,7 @@ trait Initializable {
 
   trait Config {
     def context: ServletContext
-    def initParameters: Map[String, String]
+    def getInitParameterOption(key: String): Option[String]
   }
   protected implicit def configWrapper(config: ConfigT): Config
 

--- a/core/src/main/scala/org/scalatra/FlashMap.scala
+++ b/core/src/main/scala/org/scalatra/FlashMap.scala
@@ -9,6 +9,8 @@ import scala.collection.JavaConverters._
  * A FlashMap is the data structure used by [[org.scalatra.FlashMapSupport]]
  * to allow passing temporary values between sequential actions.
  *
+ * As of Scalatra 2.7.x, it does not directly inherit Map.
+ *
  * @see FlashMapSupport
  */
 class FlashMap extends Serializable {
@@ -21,6 +23,7 @@ class FlashMap extends Serializable {
    * Removes an entry from the flash map.  It is no longer available for this
    * request or the next.
    */
+  @deprecated("FlashMap#+= has been deprecated, please use remove method instead", "2.7.0")
   def -=(key: String): FlashMap.this.type = {
     m -= key
     this
@@ -29,6 +32,7 @@ class FlashMap extends Serializable {
   /**
    * Adds an entry to the flash map.  Clears the sweep flag for the key.
    */
+  @deprecated("FlashMap#+= has been deprecated, please use update method instead", "2.7.0")
   def +=(kv: (String, Any)): FlashMap.this.type = {
     flagged -= kv._1
     m += kv
@@ -41,6 +45,14 @@ class FlashMap extends Serializable {
   def update(key: String, value: Any): Unit = {
     flagged -= key
     m.update(key, value)
+  }
+
+  /**
+   * Removes an entry from the flash map.  It is no longer available for this
+   * request or the next.
+   */
+  def remove(key: String): Any = {
+    m.remove(key)
   }
 
   /**

--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -773,8 +773,8 @@ trait ScalatraBase
    *         `None` if the parameter is not set.
    */
   def initParameter(name: String): Option[String] = {
-    config.initParameters.get(name) orElse {
-      servletContext.initParameters.get(name)
+    config.getInitParameterOption(name) orElse {
+      Option(servletContext.getInitParameter(name))
     }
   }
 

--- a/core/src/main/scala/org/scalatra/servlet/RichServletContext.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichServletContext.scala
@@ -6,8 +6,6 @@ import java.{ util => jutil }
 import javax.servlet.http.{ HttpServlet, HttpServletRequest }
 import javax.servlet.{ DispatcherType, Filter, ServletContext }
 
-import scala.collection.mutable
-
 /**
  * Extension methods to the standard ServletContext.
  */
@@ -187,33 +185,7 @@ case class RichServletContext(sc: ServletContext) extends AttributesMap {
    * absent, as an init parameter.  The default value is `DEVELOPMENT`.
    */
   def environment: String = {
-    sys.props.get(EnvironmentKey) orElse initParameters.get(EnvironmentKey) getOrElse ("DEVELOPMENT")
-  }
-
-  object initParameters extends mutable.Map[String, String] {
-
-    def get(key: String): Option[String] = Option(sc.getInitParameter(key))
-
-    def iterator: Iterator[(String, String)] = {
-      val theInitParams = sc.getInitParameterNames
-      new Iterator[(String, String)] {
-        override def hasNext: Boolean = theInitParams.hasMoreElements
-        override def next(): (String, String) = {
-          val nm = theInitParams.nextElement()
-          (nm, sc.getInitParameter(nm))
-        }
-      }
-    }
-
-    def +=(kv: (String, String)): this.type = {
-      sc.setInitParameter(kv._1, kv._2)
-      this
-    }
-
-    def -=(key: String): this.type = {
-      sc.setInitParameter(key, null)
-      this
-    }
+    sys.props.get(EnvironmentKey) orElse Option(sc.getInitParameter(EnvironmentKey)) getOrElse ("DEVELOPMENT")
   }
 
   def contextPath: String = sc.getContextPath

--- a/core/src/main/scala/org/scalatra/servlet/ServletBase.scala
+++ b/core/src/main/scala/org/scalatra/servlet/ServletBase.scala
@@ -30,28 +30,7 @@ trait ServletBase
 
     override def context: ServletContext = config.getServletContext
 
-    object initParameters extends collection.immutable.Map[String, String] {
-
-      override def get(key: String): Option[String] = Option(config.getInitParameter(key))
-
-      override def +[V1 >: String](kv: (String, V1)): Map[String, V1] = {
-        val b = Map.newBuilder[String, V1]
-        b ++= this
-        b += ((kv._1, kv._2))
-        b.result()
-      }
-
-      override def -(key: String): Map[String, String] = {
-        val b = this.newBuilder
-        for (kv <- this; if kv._1 != key) b += kv
-        b.result()
-      }
-
-      override def iterator: Iterator[(String, String)] = {
-        for (name <- config.getInitParameterNames.asScala)
-          yield (name, config.getInitParameter(name))
-      }
-    }
+    def getInitParameterOption(key: String): Option[String] = Option(config.getInitParameter(key))
 
   }
 

--- a/core/src/test/scala/org/scalatra/FlashMapTest.scala
+++ b/core/src/test/scala/org/scalatra/FlashMapTest.scala
@@ -122,12 +122,6 @@ class FlashMapTest extends FunSuite with Matchers with BeforeAndAfterEach {
     flash.get("foo") should equal(None)
   }
 
-  test("supports symbols as keys") {
-    flash("foo") = "bar"
-    flash.sweep()
-    flash('foo) should equal("bar")
-  }
-
   test("is serializable") {
     flash("foo") = "bar"
     val out = new ObjectOutputStream(new ByteArrayOutputStream)

--- a/core/src/test/scala/org/scalatra/FlashMapTest.scala
+++ b/core/src/test/scala/org/scalatra/FlashMapTest.scala
@@ -58,7 +58,7 @@ class FlashMapTest extends FunSuite with Matchers with BeforeAndAfterEach {
 
   test("values are removed immediately") {
     flash("foo") = "bar"
-    flash -= "foo"
+    flash.remove("foo")
     flash.get("foo") should equal(None)
   }
 

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalatraRenderContext.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalatraRenderContext.scala
@@ -19,9 +19,9 @@ class ScalatraRenderContext(
   req: HttpServletRequest,
   res: HttpServletResponse) extends ServletRenderContext(engine, out, req, res, kernel.servletContext) with ScalatraFormsHelpers {
 
-  def flash: scala.collection.Map[String, Any] = kernel match {
+  def flash: FlashMap = kernel match {
     case flashMapSupport: FlashMapSupport => flashMapSupport.flash(request)
-    case _ => Map.empty
+    case _ => new FlashMap
   }
 
   def session: HttpSession = kernel.session(request)


### PR DESCRIPTION
Since there was a place inevitable to inherit Map, I deleted inheritance.

In order to pass compilation with Scala 2.13, I would like to delete Map inheritance as much as possible.
It was a part that does not use Map which inherited at all in the first place.