### PR TITLE
Remove parentheses from method call

### DIFF
--- a/core/src/main/scala/org/scalatra/FutureSupport.scala
+++ b/core/src/main/scala/org/scalatra/FutureSupport.scala
@@ -50,7 +50,7 @@ trait FutureSupport extends AsyncSupport {
     val gotResponseAlready = new AtomicBoolean(false)
     val context = request.startAsync(request, response)
     timeout.foreach { timeout =>
-      if (timeout.isFinite()) context.setTimeout(timeout.toMillis) else context.setTimeout(-1)
+      if (timeout.isFinite) context.setTimeout(timeout.toMillis) else context.setTimeout(-1)
     }
 
     def renderFutureResult(f: Future[_]): Unit = {


### PR DESCRIPTION
From Scala 2.13 parenthesis was deleted from isFinite definition,
so in addition to that, parentheses at method invocation are deleted

An error will occur if parentheses remain attached.