### PR TITLE
added ToList

### DIFF
--- a/forms/src/main/scala/org/scalatra/forms/package.scala
+++ b/forms/src/main/scala/org/scalatra/forms/package.scala
@@ -272,7 +272,7 @@ package object forms {
     }
 
     private def extractMapParams(params: Map[String, Seq[String]]): Map[Int, Map[String, Seq[String]]] = {
-      params.flatMap {
+      params.toList.flatMap {
         case (key, value :: _) => key match {
           case IndexedMapParamPattern(_, i, s) => Some((i.toInt, s.replaceAll("\\]\\[", "."), value))
           case _ => None


### PR DESCRIPTION
As conversion from scala.collection.immutable.Map[K2,V2] to
scala.collection.immutable.Iterable[B] is not possible in Scala 2.13,
it will be an error