### PR TITLE
Added toList

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
@@ -60,7 +60,7 @@ trait SwaggerAuthBase[TypeForUser <: AnyRef] extends SwaggerBaseBase { self: Cor
     docs.collect {
       case doc if doc.apis.exists(_.operations.exists(_.allows(userOption))) =>
         filterDoc(doc)
-    }
+    }.toList
   }
 
 }


### PR DESCRIPTION
As conversion from scala.collection.View to
scala.collection.immutable.List is not possible
in Scala 2.13, it will be an error

scala.collection.View$Collect cannot be cast to class scala.collection.immutable.List