### PR TITLE
Added explicit `toIndexedSeq`

### DIFF
--- a/core/src/main/scala/org/scalatra/CorsSupport.scala
+++ b/core/src/main/scala/org/scalatra/CorsSupport.scala
@@ -81,9 +81,9 @@ trait CorsSupport extends Handler with Initializable { self: ScalatraBase =>
   abstract override def initialize(config: ConfigT): Unit = {
     super.initialize(config)
     def createDefault: CORSConfig = CORSConfig(
-      Option(config.context.getInitParameter(AllowedOriginsKey)).getOrElse(AnyOrigin).split(",").map(_.trim),
-      Option(config.context.getInitParameter(AllowedMethodsKey)).getOrElse(DefaultMethods).split(",").map(_.trim),
-      Option(config.context.getInitParameter(AllowedHeadersKey)).getOrElse(DefaultHeaders).split(",").map(_.trim),
+      Option(config.context.getInitParameter(AllowedOriginsKey)).getOrElse(AnyOrigin).split(",").toIndexedSeq.map(_.trim),
+      Option(config.context.getInitParameter(AllowedMethodsKey)).getOrElse(DefaultMethods).split(",").toIndexedSeq.map(_.trim),
+      Option(config.context.getInitParameter(AllowedHeadersKey)).getOrElse(DefaultHeaders).split(",").toIndexedSeq.map(_.trim),
       Option(config.context.getInitParameter(AllowCredentialsKey)).map(_.toBoolean).getOrElse(true),
       Option(config.context.getInitParameter(PreflightMaxAgeKey)).map(_.toInt).getOrElse(1800),
       Option(config.context.getInitParameter(EnableKey)).map(_.toBoolean).getOrElse(true))

--- a/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
@@ -91,7 +91,7 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
       val queryStringParams: Map[String, Seq[String]] = util.MapQueryString.parseString(r.getQueryString)
       queryStringParams ++ bodyParams
     } else {
-      val paramMap = r.getParameterMap.asScala.toMap.transform { (k, v) => v: Seq[String] }
+      val paramMap = r.getParameterMap.asScala.toMap.transform { (k, v) => v.toIndexedSeq }
       paramMap ++ bodyParams
     }
     // Allow access to multiple parameters with ruby like syntax without []

--- a/core/src/main/scala/org/scalatra/util/RequestLogging.scala
+++ b/core/src/main/scala/org/scalatra/util/RequestLogging.scala
@@ -29,7 +29,7 @@ trait RequestLogging extends ScalatraBase with Handler {
   import org.scalatra.util.RequestLogging._
 
   abstract override def handle(req: HttpServletRequest, res: HttpServletResponse): Unit = {
-    val realMultiParams = req.getParameterMap.asScala.toMap transform { (k, v) => v: Seq[String] }
+    val realMultiParams = req.getParameterMap.asScala.toMap transform { (k, v) => v.toIndexedSeq }
     withRequest(req) {
       request(MultiParamsKey) = realMultiParams
       request(CgiParamsKey) = readCgiParams(req)

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/ManifestFactory.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/ManifestFactory.scala
@@ -12,9 +12,9 @@ private[swagger] object ManifestFactory {
       val typeArgs = pt.getActualTypeArguments map manifestOf
 
       if (pt.getOwnerType == null) {
-        manifestOf(clazz, typeArgs)
+        manifestOf(clazz, typeArgs.toIndexedSeq)
       } else {
-        Manifest.classType(manifestOf(pt.getOwnerType), clazz, typeArgs: _*)
+        Manifest.classType(manifestOf(pt.getOwnerType), clazz, typeArgs.toIndexedSeq: _*)
       }
 
     case at: GenericArrayType =>

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/ParameterNameReader.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/ParameterNameReader.scala
@@ -10,5 +10,5 @@ trait ParameterNameReader {
 object ParanamerReader extends ParameterNameReader {
   private[this] val paranamer = new CachingParanamer(new BytecodeReadingParanamer)
   def lookupParameterNames(constructor: JConstructor[_]): Seq[String] =
-    paranamer.lookupParameterNames(constructor)
+    paranamer.lookupParameterNames(constructor).toIndexedSeq
 }

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
@@ -141,7 +141,7 @@ object Reflector {
               allCatch opt { paramNameReader.lookupParameterNames(ctor) } getOrElse Nil
             else
               Nil
-            val genParams = Vector(ctor.getGenericParameterTypes: _*)
+            val genParams = ctor.getGenericParameterTypes
             val ctorParams = ctorParameterNames.zipWithIndex map {
               case (paramName, index) =>
                 val decoded = unmangleName(paramName)


### PR DESCRIPTION
Implicit conversion from Array to Seq is deprecated as of Scala 2.13