### PR TITLE
Added extra fields to Swagger 2.0 parameters

### DIFF
--- a/swagger/src/main/java/org/scalatra/swagger/runtime/annotations/ApiModelProperty.java
+++ b/swagger/src/main/java/org/scalatra/swagger/runtime/annotations/ApiModelProperty.java
@@ -42,4 +42,19 @@ public @interface ApiModelProperty {
     * ordering, you should specify property order to keep models consistent across different VM implementations and versions.
     */
     int position() default 0;
+
+    /**
+     * Example value of the property
+     */
+    String example() default "";
+
+    /**
+     * Minimum value of the property
+     */
+    double minimumValue() default Double.NaN;
+
+    /**
+     * Maximum value of the property
+     */
+    double maximumValue() default Double.NaN;
 }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerAuth.scala
@@ -6,7 +6,7 @@ import org.scalatra.auth.ScentrySupport
 import org.scalatra.swagger.DataType.ValueDataType
 import org.scalatra.util.NotNothing
 
-class SwaggerWithAuth(val swaggerVersion: String, val apiVersion: String, val apiInfo: ApiInfo) extends SwaggerEngine[AuthApi[AnyRef]] {
+class SwaggerWithAuth(val swaggerVersion: String, val apiVersion: String, val apiInfo: ApiInfo, val host: String = "") extends SwaggerEngine[AuthApi[AnyRef]] {
 
   /**
    * Registers the documentation for an API with the given path.

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -171,6 +171,11 @@ object SwaggerSupportSyntax {
 
     def defaultValue: Option[String] = None
 
+    def minimumValue: Option[Double] = None
+    def maximumValue: Option[Double] = None
+    def example: Option[String] = None
+    def position: Option[Int] = None
+
     def name: String = _name
     def description: Option[String] = _description
     def paramType: ParamType.ParamType = _paramType
@@ -192,7 +197,7 @@ object SwaggerSupportSyntax {
     }
 
     def result =
-      Parameter(name, dataType, description, paramType, defaultValue, allowableValues, isRequired)
+      Parameter(name, dataType, description, paramType, defaultValue, allowableValues, isRequired, position.getOrElse(0), example, minimumValue, maximumValue)
   }
 
   class ParameterBuilder[T: Manifest](initialDataType: DataType) extends SwaggerParameterBuilder {
@@ -202,6 +207,34 @@ object SwaggerSupportSyntax {
     def defaultValue(value: T): this.type = {
       if (_required.isEmpty) optional
       _defaultValue = allCatch.withApply(_ => None) { value.toString.blankOption }
+      this
+    }
+
+    private[this] var _minimumValue: Option[Double] = None
+    override def minimumValue = _minimumValue
+    def minimumValue(value: Double): this.type = {
+      _minimumValue = Option(value)
+      this
+    }
+
+    private[this] var _maximumValue: Option[Double] = None
+    override def maximumValue = _maximumValue
+    def maximumValue(value: Double): this.type = {
+      _maximumValue = Option(value)
+      this
+    }
+
+    private[this] var _example: Option[String] = None
+    override def example = _example
+    def example(value: String): this.type = {
+      _example = Option(value)
+      this
+    }
+
+    private[this] var _position: Option[Int] = None
+    override def position = _position
+    def position(value: Int): this.type = {
+      _position = Option(value)
       this
     }
   }

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -121,7 +121,8 @@
             "description": "ID of pet that needs to be fetched",
             "required": true,
             "in": "path",
-            "type": "string"
+            "type": "string",
+            "example": "55"
           }
         ],
         "responses": {
@@ -198,7 +199,8 @@
             "description": "ID of pet that needs to be fetched",
             "required": true,
             "in": "path",
-            "type": "string"
+            "type": "string",
+            "example": "55"
           }
         ],
         "responses": {

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -121,8 +121,7 @@
             "description": "ID of pet that needs to be fetched",
             "required": true,
             "in": "path",
-            "type": "string",
-            "example": "55"
+            "type": "string"
           }
         ],
         "responses": {
@@ -199,8 +198,7 @@
             "description": "ID of pet that needs to be fetched",
             "required": true,
             "in": "path",
-            "type": "string",
-            "example": "55"
+            "type": "string"
           }
         ],
         "responses": {

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -194,7 +194,7 @@ class SwaggerSpec2 extends ScalatraSpec with JsonMatchers {
             val mm = verifyFields(
               v,
               ef find (_ \ "name" == v \ "name") get,
-              "allowableValues", "type", "$ref", "items", "paramType", "defaultValue", "description", "name", "required", "paramAccess")
+              "allowableValues", "type", "$ref", "items", "paramType", "defaultValue", "description", "name", "required", "paramAccess", "example", "minimumValue", "maximumValue")
             mm setMessage (mm.message + " in parameter " + (v \ "name").extractOrElse("N/A"))
           }
 
@@ -231,7 +231,7 @@ class SwaggerTestServlet(protected val swagger: Swagger) extends ScalatraServlet
       summary "Find pet by ID"
       description "Returns a pet based on ID"
       responseMessages (ResponseMessage(400, "Invalid ID supplied").model[Error], ResponseMessage(404, "Pet not found"))
-      parameter pathParam[String]("petId").description("ID of pet that needs to be fetched")
+      parameter pathParam[String]("petId").description("ID of pet that needs to be fetched").example( "55" )
       produces ("application/json", "application/xml")
       authorizations ("oauth2"))
 
@@ -316,7 +316,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
       description "For valid response try integer IDs with value <= 5. Anything above 5 or nonintegers will generate API errors"
       produces ("application/json", "application/xml")
       tags ("store")
-      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched").required
+      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched" ).example( "55" ).required
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
         ResponseMessage(404, "Order not found")))

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -316,7 +316,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
       description "For valid response try integer IDs with value <= 5. Anything above 5 or nonintegers will generate API errors"
       produces ("application/json", "application/xml")
       tags ("store")
-      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched" ).required
+      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched").required
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
         ResponseMessage(404, "Order not found")))

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -231,7 +231,7 @@ class SwaggerTestServlet(protected val swagger: Swagger) extends ScalatraServlet
       summary "Find pet by ID"
       description "Returns a pet based on ID"
       responseMessages (ResponseMessage(400, "Invalid ID supplied").model[Error], ResponseMessage(404, "Pet not found"))
-      parameter pathParam[String]("petId").description("ID of pet that needs to be fetched").example( "55" )
+      parameter pathParam[String]("petId").description("ID of pet that needs to be fetched")
       produces ("application/json", "application/xml")
       authorizations ("oauth2"))
 
@@ -316,7 +316,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
       description "For valid response try integer IDs with value <= 5. Anything above 5 or nonintegers will generate API errors"
       produces ("application/json", "application/xml")
       tags ("store")
-      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched" ).example( "55" ).required
+      parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched" ).required
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
         ResponseMessage(404, "Order not found")))


### PR DESCRIPTION
Added `example`, `minimumValue`, and `maximumValue` fields to Swagger endpoint parameters