### PR TITLE
use xenial and openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ scala:
   - 2.12.8
   - 2.13.0-RC1
 jdk:
-  - oraclejdk8
+  - openjdk8
+dist: xenial
 sudo: false
 script:
 - sbt ++$TRAVIS_SCALA_VERSION test unidoc
@@ -15,6 +16,3 @@ matrix:
     scala: 2.12.8
     script:
     - sbt ++$TRAVIS_SCALA_VERSION test
-    before_install:
-      - rm "${JAVA_HOME}/lib/security/cacerts"
-      - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-08-xenial-release
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.