### PR TITLE
avoid deprecated scala.Symbol literals

### DIFF
--- a/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
+++ b/atmosphere/src/main/scala/org/scalatra/atmosphere/AtmosphereSupport.scala
@@ -156,7 +156,7 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
   private[this] def noGetRoute = sys.error("You are using the AtmosphereSupport without defining any Get route," +
     "you should get rid of it.")
 
-  private[this] def atmosphereRoutes = routes.methodRoutes.getOrElse(Get, noGetRoute).filter(_.metadata.contains('Atmosphere))
+  private[this] def atmosphereRoutes = routes.methodRoutes.getOrElse(Get, noGetRoute).filter(_.metadata.contains(Symbol("Atmosphere")))
 
   private[this] def atmosphereRoute(req: HttpServletRequest) = (for {
     route <- atmosphereRoutes.toStream
@@ -177,7 +177,7 @@ trait AtmosphereSupport extends Initializable with Handler with CometProcessor w
   }
 
   private[atmosphere] val Atmosphere: RouteTransformer = { (route: Route) =>
-    route.copy(metadata = route.metadata + ('Atmosphere -> 'Atmosphere))
+    route.copy(metadata = route.metadata + (Symbol("Atmosphere") -> Symbol("Atmosphere")))
   }
 
   def atmosphere(transformers: RouteTransformer*)(block: => AtmosphereClient): Unit = {

--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -81,7 +81,7 @@ trait ApiFormats extends ScalatraBase {
   /**
    * The default format.
    */
-  def defaultFormat: Symbol = 'html
+  def defaultFormat: Symbol = Symbol("html")
 
   /**
    * A list of formats accepted by default.

--- a/core/src/test/scala/org/scalatra/RouteMetadataSpec.scala
+++ b/core/src/test/scala/org/scalatra/RouteMetadataSpec.scala
@@ -34,11 +34,11 @@ object RouteMetadataSpec {
       zero.metadata.size.toString
     }
 
-    val one: Route = get("/one/:key", meta('foo, "bar")) {
+    val one: Route = get("/one/:key", meta(Symbol("foo"), "bar")) {
       renderMeta(one, Symbol(params("key")))
     }
 
-    val two: Route = get("/two/:key", meta('foo, "bar"), meta('foo, "baz")) {
+    val two: Route = get("/two/:key", meta(Symbol("foo"), "bar"), meta(Symbol("foo"), "baz")) {
       renderMeta(two, Symbol(params("key")))
     }
 


### PR DESCRIPTION
Symbol literal deprecated since Scala 2.13