### PR TITLE
Support basic auth for Swagger rendering

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -465,6 +465,10 @@ case class ApiKey(keyName: String, passAs: String = "header", description: Strin
   override val `type` = "apiKey"
 }
 
+case class BasicAuth(keyName: String, description: String = "") extends AuthorizationType {
+  override val `type` = "basic"
+}
+
 trait GrantType {
   def `type`: String
 }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -200,11 +200,9 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                     JField("name", a.keyName),
                     JField("in", a.passAs))))
                   case a: BasicAuth => Some(((a.keyName -> JObject(
-                    JField("type","basic"),
-                    JField("description",a.description),
-                    JField("name",a.keyName)
-                  )))
-                  )
+                    JField("type", "basic"),
+                    JField("description", a.description),
+                    JField("name", a.keyName)))))
                 })
               }).toMap)
   }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -143,6 +143,7 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                             swagger.authorizations.find(_.keyName == requirement).map {
                               case a: OAuth => (requirement -> a.scopes)
                               case b: ApiKey => (requirement -> List.empty)
+                              case c: BasicAuth => (requirement -> List.empty)
                               case _ => (requirement -> List.empty)
                             }
                           }))))
@@ -198,6 +199,12 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                     JField("description", a.description),
                     JField("name", a.keyName),
                     JField("in", a.passAs))))
+                  case a: BasicAuth => Some(((a.keyName -> JObject(
+                    JField("type","basic"),
+                    JField("description",a.description),
+                    JField("name",a.keyName)
+                  )))
+                  )
                 })
               }).toMap)
   }

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -295,7 +295,12 @@
           "405": {
             "description": "Invalid input"
           }
-        }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
       },
       "put": {
         "operationId": "updatePet",
@@ -445,6 +450,11 @@
     }
   },
   "securityDefinitions": {
+    "basicAuth": {
+      "type": "basic",
+      "description": "",
+      "name": "basicAuth"
+    },
     "oauth2": {
       "type": "oauth2",
       "description": "",

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -35,6 +35,7 @@ class SwaggerSpec2 extends ScalatraSpec with JsonMatchers {
       name = "Apache 2.0",
       url = "http://www.apache.org/licenses/LICENSE-2.0.html"))
   val swagger = new Swagger("2.0", "1.0.0", apiInfo)
+  swagger.addAuthorization(BasicAuth("basicAuth"))
   swagger.addAuthorization(ApiKey("apiKey"))
   swagger.addAuthorization(ApiKey("Authorization1", "query", "you must register your app to receive an apikey"))
   swagger.addAuthorization(OAuth(
@@ -243,7 +244,8 @@ class SwaggerTestServlet(protected val swagger: Swagger) extends ScalatraServlet
     (apiOperation[Unit]("addPet")
       summary "Add a new pet to the store"
       responseMessage ResponseMessage(405, "Invalid input")
-      parameter bodyParam[Pet].description("Pet object that needs to be added to the store"))
+      parameter bodyParam[Pet].description("Pet object that needs to be added to the store")
+      authorizations ("basicAuth"))
 
   post("/", operation(createPet)) {
     ApiResponse(ApiResponseType.OK, "pet added to store")


### PR DESCRIPTION
Added support for basic auth in Swagger rendering for OpenAPI 2.0

Related issue: #974 