### PR TITLE
Swagger: Add a default HTTP 200 response ONLY if there's no other 2xx responses

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -151,6 +151,13 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                   doc.apis.collect {
                     case api: SwaggerEndpoint[_] =>
                       (api.path -> api.operations.map { operation =>
+                        val responses = operation.responseMessages.map { response =>
+                          (response.code.toString ->
+                            ("description", response.message) ~~
+                            response.responseModel.map { model =>
+                              List(JField("schema", JObject(JField("$ref", s"#/definitions/${model}"))))
+                            }.getOrElse(Nil))
+                        }.toMap
                         (operation.method.toString.toLowerCase -> (
                           ("operationId" -> operation.operationId) ~
                           ("summary" -> operation.summary) ~!
@@ -172,26 +179,21 @@ trait SwaggerBaseBase extends Initializable with ScalatraBase { self: JsonSuppor
                               })
                           }) ~
                           ("responses" ->
-                            ("200" ->
-                              (if (operation.responseClass.name == "void") {
-                                List(JField("description", "No response"))
-                              } else {
-                                List(JField("description", "OK"), JField("schema", generateDataType(operation.responseClass)))
-                              })) ~
-                              operation.responseMessages.map { response =>
-                                (response.code.toString ->
-                                  ("description", response.message) ~~
-                                  response.responseModel.map { model =>
-                                    List(JField("schema", JObject(JField("$ref", s"#/definitions/${model}"))))
-                                  }.getOrElse(Nil))
-                              }.toMap) ~!
-                              ("security" -> (operation.authorizations.flatMap { requirement =>
-                                swagger.authorizations.find(_.`keyname` == requirement).map {
-                                  case a: OAuth => (requirement -> a.scopes)
-                                  case b: ApiKey => (requirement -> List.empty)
-                                  case _ => (requirement -> List.empty)
-                                }
-                              }))))
+                            (if (responses.nonEmpty && responses.keySet.exists(_.startsWith("2"))) responses else {
+                              responses + ("200" ->
+                                (if (operation.responseClass.name == "void") {
+                                  JObject(JField("description", "No response"))
+                                } else {
+                                  JObject(JField("description", "OK"), JField("schema", generateDataType(operation.responseClass)))
+                                }))
+                            })) ~!
+                            ("security" -> (operation.authorizations.flatMap { requirement =>
+                              swagger.authorizations.find(_.`keyname` == requirement).map {
+                                case a: OAuth => (requirement -> a.scopes)
+                                case b: ApiKey => (requirement -> List.empty)
+                                case _ => (requirement -> List.empty)
+                              }
+                            }))))
                       })
                   }
               }: _*)) ~

--- a/swagger/src/test/resources/store.json
+++ b/swagger/src/test/resources/store.json
@@ -78,18 +78,23 @@
           "method": "POST",
           "summary": "Place an order for a pet",
           "notes": "",
-          "type": "void",
+          "type": "Order",
           "nickname": "placeOrder",
           "parameters": [
             {
               "name": "body",
               "description": "order placed for purchasing the pet",
-              "required": true
+              "required": true,
               "type": "Order",
               "paramType": "body"
             }
           ],
           "responseMessages": [
+            {
+              "code": 201,
+              "message": "Created",
+              "responseModel": "Order"
+            },
             {
               "code": 400,
               "message": "Invalid order"

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -32,8 +32,11 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "No response"
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
           },
           "400": {
             "description": "Invalid order"

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -601,11 +601,14 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
   }
 
   val placeOrderOperation =
-    (apiOperation[Unit]("placeOrder")
+    (apiOperation[Order]("placeOrder")
       summary "Place an order for a pet"
       tags ("store")
-      responseMessage ResponseMessage(400, "Invalid order")
-      parameter bodyParam[Order].description("order placed for purchasing the pet"))
+      responseMessages (
+        ResponseMessage(201, "Created", Some(Order.toString())),
+        ResponseMessage(400, "Invalid order"))
+        parameter bodyParam[Order].description("order placed for purchasing the pet"))
+
   post("/order", operation(placeOrderOperation)) {
     ""
   }


### PR DESCRIPTION
Fixes https://github.com/scalatra/scalatra/issues/798

If a provided list of responses already contains any 2xx code, there's no need to add a default 200 one. 

_Before_:
<img width="561" alt="Screen Shot 2019-10-12 at 8 47 45 PM" src="https://user-images.githubusercontent.com/72321/66706378-fd474e80-ed31-11e9-8d14-c4765cdf7420.png">

_Now_:
<img width="543" alt="Screen Shot 2019-10-12 at 8 49 33 PM" src="https://user-images.githubusercontent.com/72321/66706380-06382000-ed32-11e9-9520-c1c865d3d53a.png">