### PR TITLE
[2.7.x] Swagger: Add a default HTTP 200 response ONLY if there's no other 2xx responses

### DIFF
--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -34,8 +34,11 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "No response"
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
           },
           "400": {
             "description": "Invalid order"

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -339,11 +339,15 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
   }
 
   val placeOrderOperation =
-    (apiOperation[Unit]("placeOrder")
+    (apiOperation[Order]("placeOrder")
       summary "Place an order for a pet"
       tags ("store")
       responseMessage ResponseMessage(400, "Invalid order")
-      parameter bodyParam[Order].description("order placed for purchasing the pet"))
+      responseMessages (
+        ResponseMessage(201, "Created", Some(Order.toString())),
+        ResponseMessage(400, "Invalid order"))
+        parameter bodyParam[Order].description("order placed for purchasing the pet"))
+
   post("/order", operation(placeOrderOperation)) {
     ""
   }


### PR DESCRIPTION
Fixes https://github.com/scalatra/scalatra/issues/798

If a provided list of responses already contains any 2xx code, there's no need to add a default 200 one. 

_Before_:
<img width="561" alt="Screen Shot 2019-10-12 at 8 47 45 PM" src="https://user-images.githubusercontent.com/72321/66706378-fd474e80-ed31-11e9-8d14-c4765cdf7420.png">

_Now_:
<img width="543" alt="Screen Shot 2019-10-12 at 8 49 33 PM" src="https://user-images.githubusercontent.com/72321/66706380-06382000-ed32-11e9-9520-c1c865d3d53a.png">