### PR TITLE
Excluded '#' and '&' from path separator

### DIFF
--- a/core/src/main/scala/org/scalatra/PathPatternParsers.scala
+++ b/core/src/main/scala/org/scalatra/PathPatternParsers.scala
@@ -84,7 +84,7 @@ class SinatraPathPatternParser extends RegexPathPatternParser {
   private def splat = "*" ^^^ PartialPathPattern("(.*?)", List("splat"))
 
   private def namedGroup = ":" ~> """\w+""".r ^^
-    { groupName => PartialPathPattern("([^/?#]+)", List(groupName)) }
+    { groupName => PartialPathPattern("([^/]+)", List(groupName)) }
 
   private def literal = metaChar | normalChar
 
@@ -122,7 +122,7 @@ class RailsPathPatternParser extends RegexPathPatternParser {
   private def token = param | glob | optional | static
 
   private def param = ":" ~> identifier ^^
-    { name => PartialPathPattern("([^#/.?]+)", List(name)) }
+    { name => PartialPathPattern("([^/.]+)", List(name)) }
 
   private def identifier = """[a-zA-Z_]\w*""".r
 

--- a/core/src/test/scala/org/scalatra/RailsPathPatternParserTest.scala
+++ b/core/src/test/scala/org/scalatra/RailsPathPatternParserTest.scala
@@ -15,13 +15,13 @@ class RailsPathPatternParserTest extends FunSuite with Matchers {
 
   test("dynamic segment") {
     val PathPattern(re, names) = RailsPathPatternParser(":foo.example.com")
-    re.toString should equal("""\A([^#/.?]+)\.example\.com\Z""")
+    re.toString should equal("""\A([^/.]+)\.example\.com\Z""")
     names should equal(List("foo"))
   }
 
   test("dynamic segment with leading underscore") {
     val PathPattern(re, names) = RailsPathPatternParser(":_foo.example.com")
-    re.toString should equal("""\A([^#/.?]+)\.example\.com\Z""")
+    re.toString should equal("""\A([^/.]+)\.example\.com\Z""")
     names should equal(List("_foo"))
   }
 
@@ -45,7 +45,7 @@ class RailsPathPatternParserTest extends FunSuite with Matchers {
 
   test("dynamic segment inside optional segment") {
     val PathPattern(re, names) = RailsPathPatternParser("foo(.:extension)")
-    re.toString should equal("""\Afoo(?:\.([^#/.?]+))?\Z""")
+    re.toString should equal("""\Afoo(?:\.([^/.]+))?\Z""")
     names should equal(List("extension"))
   }
 

--- a/core/src/test/scala/org/scalatra/SinatraPathPatternParserTest.scala
+++ b/core/src/test/scala/org/scalatra/SinatraPathPatternParserTest.scala
@@ -27,7 +27,7 @@ class SinatraPathPatternParserTest extends FunSuite with Matchers {
   test("should capture named groups") {
     val PathPattern(pattern, names) = SinatraPathPatternParser("/path/:group")
 
-    pattern.toString should equal("""^/path/([^/?#]+)$""")
+    pattern.toString should equal("""^/path/([^/]+)$""")
     names should equal(List("group"))
   }
 
@@ -41,14 +41,14 @@ class SinatraPathPatternParserTest extends FunSuite with Matchers {
   test("allow optional named groups") {
     val PathPattern(pattern, names) = SinatraPathPatternParser("/optional/?:stuff?")
 
-    pattern.toString should equal("""^/optional/?([^/?#]+)?$""")
+    pattern.toString should equal("""^/optional/?([^/]+)?$""")
     names should equal(List("stuff"))
   }
 
   test("should support seperate named params for filename and extension") {
     val PathPattern(pattern, names) = SinatraPathPatternParser("/path-with/:file.:extension")
 
-    pattern.toString should equal("""^/path-with/([^/?#]+)\.([^/?#]+)$""")
+    pattern.toString should equal("""^/path-with/([^/]+)\.([^/]+)$""")
     names should equal(List("file", "extension"))
   }
 }


### PR DESCRIPTION
The parser generated by `SinatraPathPatternParser` generates
a regular expression `([^/?#]+)` for namedGroup.

With this regular expression, we can extract the character string up
to the front of `/` or `?` or `#`.

For example, the route `/file/to/scalatra.jar/hit` matches the route
definition `get("file/to/:path/hit")` and `params("path")` contains
`scalatra.jar`.

However, the source of the path is the `requestPath` method, and
`#` and `&` are removed in advance from the path returned by this
method (since the query and fragment are deleted from path).

In other words, `([^/]+)` is enough for the regular expression
to be generated.

The same applies to RailsPathPatternParser
(Rails has dot notation, so it becomes `([^/.]+)`)