### PR TITLE
replaced StringEscapeUtils's package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val scalatraCore = Project(
       servletApi % "provided;test",
       slf4jApi,
       jUniversalChardet,
-      commonsLang3,
+      commonsText,
       parserCombinators.value,
       xml,
       akkaActor % "test",
@@ -193,7 +193,6 @@ lazy val scalatraTest = Project(
       jettyWebapp,
       servletApi,
       mockitoAll,
-      commonsLang3,
       httpclient,
       httpmime
     ) ++ specs2.map(_ % "test"),
@@ -385,4 +384,3 @@ lazy val mavenCentralFrouFrou = Seq(
 )
 
 lazy val doNotPublish = Seq(publish := {}, publishLocal := {}, PgpKeys.publishSigned := {}, PgpKeys.publishLocalSigned := {})
-

--- a/core/src/main/scala/org/scalatra/ScalatraServlet.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraServlet.scala
@@ -3,7 +3,7 @@ package org.scalatra
 import javax.servlet._
 import javax.servlet.http._
 
-import org.apache.commons.lang3.StringEscapeUtils
+import org.apache.commons.text.StringEscapeUtils
 import org.scalatra.servlet.ServletBase
 import org.scalatra.util.RicherString._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val atmosphereCompatTomcat7  =  "org.atmosphere"          %  "atmosphere-compat-tomcat7"  % atmosphereCompatVersion
   lazy val commonsFileupload        =  "commons-fileupload"      %  "commons-fileupload"         % "1.3.3"
   lazy val commonsIo                =  "commons-io"              %  "commons-io"                 % "2.5"
-  lazy val commonsLang3             =  "org.apache.commons"      %  "commons-lang3"              % "3.10"
+  lazy val commonsText              =  "org.apache.commons"      %  "commons-text"               % "1.8"
   lazy val httpclient               =  "org.apache.httpcomponents" % "httpclient"                % httpcomponentsVersion
   lazy val httpmime                 =  "org.apache.httpcomponents" % "httpmime"                  % httpcomponentsVersion
   lazy val jettyServer              =  "org.eclipse.jetty"       %  "jetty-server"               % jettyVersion


### PR DESCRIPTION
Because `org.apache.commons.lang3.StringEscapeUtils` is now deprecated,
it has been replaced by the alternative `org.apache.commons.text.StringEscapeUtils`.