### PR TITLE
[Swagger] Provide a new parameter that allows to hide object properties and operation parameters

### DIFF
--- a/swagger/src/main/java/org/scalatra/swagger/runtime/annotations/ApiModelProperty.java
+++ b/swagger/src/main/java/org/scalatra/swagger/runtime/annotations/ApiModelProperty.java
@@ -57,4 +57,10 @@ public @interface ApiModelProperty {
      * Maximum value of the property
      */
     double maximumValue() default Double.NaN;
+
+    /**
+     * Whether or not the property should be hidden from the Swagger documentation.
+     * @return true if it should be hidden. Otherwise false
+     */
+    boolean hidden() default false;
 }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -116,7 +116,7 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                         ("produces" -> operation.produces) ~!
                         ("tags" -> operation.tags) ~
                         ("deprecated" -> operation.deprecated) ~
-                        ("parameters" -> operation.parameters.sortBy(_.position).map { parameter =>
+                        ("parameters" -> operation.getVisibleParameters.sortBy(_.position).map { parameter =>
                           ("name" -> parameter.name) ~
                             ("description" -> parameter.description) ~
                             ("default" -> parameter.defaultValue) ~
@@ -157,7 +157,7 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                       ("type" -> "object") ~
                       ("description" -> model.description) ~
                       ("discriminator" -> model.discriminator) ~
-                      ("properties" -> model.properties.sortBy(_._2.position).map {
+                      ("properties" -> model.getVisibleProperties.sortBy(_._2.position).map {
                         case (name, property) =>
                           (name ->
                             ("example" -> toTypedAst(property.example, property.`type`)) ~
@@ -166,7 +166,7 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with CorsSupport =>
                             ("description" -> property.description) ~~
                             generateDataType(property.`type`))
                       }.toMap) ~!
-                      ("required" -> model.properties.collect {
+                      ("required" -> model.getVisibleProperties.collect {
                         case (name, property) if property.required => name
                       }))
                 }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -140,6 +140,7 @@ object SwaggerSupportSyntax {
     private[this] var _paramType: ParamType.ParamType = ParamType.Query
     private[this] var _allowableValues: AllowableValues = AllowableValues.AnyValue
     protected[this] var _required: Option[Boolean] = None
+    protected[this] var _hidden: Option[Boolean] = None
     private[this] var _paramAccess: Option[String] = None
 
     def dataType: DataType = _dataType
@@ -169,6 +170,7 @@ object SwaggerSupportSyntax {
     def allowableValues(values: Range): this.type = { _allowableValues = AllowableValues(values); this }
     def required: this.type = { _required = Some(true); this }
     def optional: this.type = { _required = Some(false); this }
+    def hidden: this.type = { _hidden = Some(true); this }
 
     def defaultValue: Option[String] = None
 
@@ -183,6 +185,7 @@ object SwaggerSupportSyntax {
     def paramAccess = _paramAccess
     def allowableValues: AllowableValues = _allowableValues
     def isRequired: Boolean = paramType == ParamType.Path || _required.forall(identity)
+    def isHidden: Boolean = _hidden.getOrElse(false)
 
     def multiValued: this.type = {
       dataType match {
@@ -198,7 +201,7 @@ object SwaggerSupportSyntax {
     }
 
     def result =
-      Parameter(name, dataType, description, paramType, defaultValue, allowableValues, isRequired, position.getOrElse(0), example, minimumValue, maximumValue)
+      Parameter(name, dataType, description, paramType, defaultValue, allowableValues, isRequired, position.getOrElse(0), example, minimumValue, maximumValue, isHidden)
   }
 
   class ParameterBuilder[T: Manifest](initialDataType: DataType) extends SwaggerParameterBuilder {

--- a/swagger/src/test/scala/org/scalatra/swagger/ModelSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/ModelSpec.scala
@@ -14,6 +14,9 @@ object ModelSpec {
   case class WithRequiredFalse(id: String, @ApiModelProperty(required = false) name: String)
   case class WithRequiredTrue(id: String, @ApiModelProperty(required = true) name: String)
 
+  case class WithHiddenFalse(id: String, @ApiModelProperty(hidden = false) name: String)
+  case class WithHiddenTrue(id: String, @ApiModelProperty(hidden = true) name: String)
+
   case class WithOption(id: String, name: Option[String])
   case class WithDefaultValue(id: String, name: String = "April")
   case class WithRequiredValue(id: String, name: String)
@@ -50,6 +53,15 @@ class ModelSpec extends Specification {
     "convert a required=true annotation of a model field" in {
       swaggerProperty[WithRequiredTrue]("name").required must beTrue
     }
+
+    "convert a hidden=false annotation of a model field" in {
+      swaggerProperty[WithHiddenFalse]("name").hidden must beFalse
+    }
+
+    "convert a hidden=true annotation of a model field" in {
+      swaggerProperty[WithHiddenTrue]("name").hidden must beTrue
+    }
+
     "convert an option to a required false" in {
       swaggerProperty[WithOption]("name").required must beFalse
     }

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -319,6 +319,7 @@ class StoreApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSupp
       produces ("application/json", "application/xml")
       tags ("store")
       parameter pathParam[String]("orderId").description("ID of pet that needs to be fetched").required
+      parameter queryParam[String]("showCoolStuff").hidden
       responseMessages (
         ResponseMessage(400, "Invalid ID supplied"),
         ResponseMessage(404, "Order not found")))
@@ -373,7 +374,8 @@ case class Order(
   @ApiModelProperty(position = 2, description = "Order Status", allowableValues = "placed,approved,delivered") status: String,
   @ApiModelProperty(position = 3) petId: Long,
   @ApiModelProperty(position = 4) quantity: Int,
-  @ApiModelProperty(position = 5) shipDate: OffsetDateTime)
+  @ApiModelProperty(position = 5) shipDate: OffsetDateTime,
+  @ApiModelProperty(hidden = true, required = true) shipped: Boolean)
 case class User(id: Long, username: String, password: String, email: String, firstName: String, lastName: String, phone: String, userStatus: Int)
 case class Pet(
   @ApiModelProperty(position = 3) id: Long,


### PR DESCRIPTION
# What

- Provide a new "hidden" parameter for @ApiModelProperty. It doesn't render the property in the Swagger spec
- Provide a new "hidden" parameter option. Allows to hide the parameter from the Swagger spec.

# Why

Sometimes you don't want to expose certain fields to the developers even if they are accessible. For this reason, we would like to not render that property in the spec.


- [x] Tests: No change to the generated spec with the new field (hidden).