### PR TITLE
[Swagger] 2-  SwaggerTag for all servlet operation

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -507,7 +507,7 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
   protected implicit def operationBuilder2operation[T](bldr: OperationBuilder): Operation = bldr.result
   protected def apiOperation[T: Manifest: NotNothing](operationId: String): OperationBuilder = {
     registerModel[T]()
-    makeOperationBuilder(operationId,DataType[T])
+    makeOperationBuilder(operationId, DataType[T])
   }
   protected def apiOperation(operationId: String, model: Model): OperationBuilder = {
     registerModel(model)
@@ -515,7 +515,7 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
   }
 
   private def makeOperationBuilder(operationId: String, dataType: DataType): OperationBuilder = {
-    val builder =  new OperationBuilder(dataType).operationId(operationId)
+    val builder = new OperationBuilder(dataType).operationId(operationId)
     swaggerTag.foreach(builder.tags(_))
     builder
   }

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -493,6 +493,8 @@ trait SwaggerSupportSyntax extends Initializable with CorsSupport {
     }
   }
 
+  protected def swaggerTag: Option[String] = None
+
 }
 
 /**
@@ -505,11 +507,17 @@ trait SwaggerSupport extends ScalatraBase with SwaggerSupportBase with SwaggerSu
   protected implicit def operationBuilder2operation[T](bldr: OperationBuilder): Operation = bldr.result
   protected def apiOperation[T: Manifest: NotNothing](operationId: String): OperationBuilder = {
     registerModel[T]()
-    new OperationBuilder(DataType[T]).operationId(operationId)
+    makeOperationBuilder(operationId,DataType[T])
   }
   protected def apiOperation(operationId: String, model: Model): OperationBuilder = {
     registerModel(model)
-    new OperationBuilder(ValueDataType(model.id)).operationId(operationId)
+    makeOperationBuilder(operationId, ValueDataType(model.id))
+  }
+
+  private def makeOperationBuilder(operationId: String, dataType: DataType): OperationBuilder = {
+    val builder =  new OperationBuilder(dataType).operationId(operationId)
+    swaggerTag.foreach(builder.tags(_))
+    builder
   }
 
   /**

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -54,6 +54,7 @@
           "application/json",
           "application/xml"
         ],
+        "tags": ["Pet"],
         "deprecated": true,
         "parameters": [
           {
@@ -147,6 +148,7 @@
       "post": {
         "operationId": "createUser",
         "summary": "",
+        "tags": ["User"],
         "deprecated": false,
         "parameters": [],
         "responses": {
@@ -164,6 +166,7 @@
         "operationId": "deletePet",
         "summary": "Deletes a pet",
         "deprecated": false,
+        "tags": ["Pet"],
         "parameters": [
           {
             "name": "petId",
@@ -194,6 +197,7 @@
           "application/json",
           "application/xml"
         ],
+        "tags": ["Pet"],
         "deprecated": false,
         "parameters": [
           {
@@ -238,6 +242,7 @@
           "application/json",
           "application/xml"
         ],
+        "tags": ["Pet"],
         "deprecated": true,
         "parameters": [
           {
@@ -276,6 +281,7 @@
       "post": {
         "operationId": "addPet",
         "summary": "Add a new pet to the store",
+        "tags": ["Pet"],
         "deprecated": false,
         "parameters": [
           {
@@ -305,6 +311,7 @@
       "put": {
         "operationId": "updatePet",
         "summary": "Update an existing pet",
+        "tags": ["Pet"],
         "deprecated": false,
         "parameters": [
           {

--- a/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
+++ b/swagger/src/test/scala/org/scalatra/swagger/SwaggerSpec.scala
@@ -221,6 +221,8 @@ class SwaggerTestServlet(protected val swagger: Swagger) extends ScalatraServlet
 
   protected override val swaggerConsumes: List[String] = Nil
 
+  override protected def swaggerTag: Option[String] = Some("Pet")
+
   val data = new PetData
 
   get("/undocumented") {
@@ -360,6 +362,8 @@ class UserApi(val swagger: Swagger) extends ScalatraServlet with NativeJsonSuppo
   protected val applicationDescription = "Operations about user"
   protected implicit val jsonFormats: Formats = DefaultFormats
   implicit val StringFormat = DefaultJsonFormats.GenericFormat(DefaultReaders.StringReader, DefaultWriters.StringWriter)
+
+  override protected def swaggerTag: Option[String] = Some("User")
 
   val createUserOperation = apiOperation[User]("createUser")
   post("/", operation(createUserOperation)) {


### PR DESCRIPTION
Allows to define a `swaggerTag` inside your trait to tag all the operations defined in the same scope.