### PR TITLE
Swagger: Provide a way to merge custom JSON into the Swagger spec at rendering

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/Swagger.scala
@@ -5,6 +5,7 @@ import java.lang.reflect.Field
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{ Date => JDate }
 
+import org.json4s.JsonAST.JValue
 import org.scalatra.swagger.reflect._
 import org.scalatra.swagger.runtime.annotations.{ ApiModel, ApiModelProperty }
 import org.slf4j.LoggerFactory
@@ -16,6 +17,7 @@ trait SwaggerEngine {
   def apiVersion: String
   def host: String
   def apiInfo: ApiInfo
+  def extraSwaggerDefinition: Option[JValue]
 
   private[swagger] val _docs = new ConcurrentHashMap[String, Api]().asScala
 
@@ -209,7 +211,7 @@ object Swagger {
 /**
  * An instance of this class is used to hold the API documentation.
  */
-class Swagger(val swaggerVersion: String, val apiVersion: String, val apiInfo: ApiInfo, val host: String = "") extends SwaggerEngine {
+class Swagger(val swaggerVersion: String, val apiVersion: String, val apiInfo: ApiInfo, val host: String = "", val extraSwaggerDefinition: Option[JValue] = None) extends SwaggerEngine {
   private[this] val logger = LoggerFactory.getLogger(getClass)
 
   /**

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -49,7 +49,11 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with JsonSupport[_]
   abstract override def initialize(config: ConfigT): Unit = {
     super.initialize(config)
     get("/swagger.json") {
-      renderSwagger2(swagger.docs.toList.asInstanceOf[List[Api]])
+      val renderedSwagger = renderSwagger2(swagger.docs.toList)
+
+      swagger.extraSwaggerDefinition.map {
+        renderedSwagger merge _
+      }.getOrElse(renderedSwagger)
     }
   }
 

--- a/swagger/src/test/resources/swagger.json
+++ b/swagger/src/test/resources/swagger.json
@@ -348,6 +348,11 @@
     }
   },
   "definitions": {
+    "Dog": {
+      "properties": {
+        "name": {"type":  "string"}
+      }
+    },
     "Pet": {
       "properties": {
         "name": {


### PR DESCRIPTION
# What

Add a new optional parameters when creating a new Swagger object. This parameters takes a JValue that would be merged with the rendered Swagger definition.

# Why

There's some corner cases where the Swagger generation might be wrong. Having a way to customize the rendered Swagger spec allows to rapidly provide a valid spec.


# Notes

I created a new spec test to test the rendered JSON when we don't provide any JSON values (I just wanted to assert that it doesn't break anything). Let me know if there's a simpler way to do that.

