### PR TITLE
Deleted unused code

### DIFF
--- a/scalate/src/main/scala/org/scalatra/scalate/ScalatraTemplateEngine.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalatraTemplateEngine.scala
@@ -1,9 +1,0 @@
-package org.scalatra.scalate
-
-import java.io.File
-
-import org.fusesource.scalate.TemplateEngine
-
-class ScalatraTemplateEngine(sourceDirectories: Iterable[File] = None, mode: String = sys.props.getOrElse("scalate.mode", "production")) extends TemplateEngine(sourceDirectories, mode) {
-
-}


### PR DESCRIPTION
The 'ScalatraTempleEngine class' is not used, instead it is used in
it is defined in ScalateSupport.scala 'ScalatraTempleteEngine trait'
is used.