### PR TITLE
deleted sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ scala:
 jdk:
   - openjdk8
 dist: xenial
-sudo: false
 script:
 - sbt ++$TRAVIS_SCALA_VERSION test unidoc
 - git diff --exit-code


### PR DESCRIPTION
Since travis has moved from a container-based environment to a VM-based
environment, there is no need to specify `sudo: false` anymore.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration