### PR TITLE
ScentryStrategy sensible default name

### DIFF
--- a/auth/src/main/scala/org/scalatra/auth/ScentryStrategy.scala
+++ b/auth/src/main/scala/org/scalatra/auth/ScentryStrategy.scala
@@ -7,7 +7,7 @@ trait ScentryStrategy[UserType <: AnyRef] {
 
   protected def app: ScalatraBase
 
-  def name: String = "NameMe"
+  def name: String = this.getClass.getName
 
   def registerWith(registrar: Scentry[UserType]): Unit = {
     if (name == "NameMe") throwOverrideException


### PR DESCRIPTION
I was trying to debug my set of strategies under debug logging to find they were all just saying "Authenticating with: NameMe" which wasn't so helpful