### PR TITLE
removed .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,8 +1,0 @@
--Dfile.encoding=UTF8
--Xms512m
--Xmx2g
--Xss4m
--XX:ReservedCodeCacheSize=128m
--Djava.awt.headless=true
--XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC


### PR DESCRIPTION
The default settings no longer fail tests, etc., and the deprecated parameters have increased, so remove