### PR TITLE
Added parentheses to overroad method

### DIFF
--- a/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
+++ b/atmosphere/src/test/scala/org/scalatra/atmosphere/AtmosphereSpec.scala
@@ -158,7 +158,7 @@ class AtmosphereSpec extends MutableScalatraSpec {
     Await.result(f, Duration(1, TimeUnit.MINUTES))
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     super.afterAll()
     stopSystem()
   }

--- a/core/src/main/scala/org/scalatra/FlashMap.scala
+++ b/core/src/main/scala/org/scalatra/FlashMap.scala
@@ -64,7 +64,7 @@ class FlashMap extends Serializable {
 
     def hasNext = it.hasNext
 
-    def next = {
+    def next() = {
       val kv = it.next()
       flagged += kv._1
       kv

--- a/core/src/test/scala/org/scalatra/ContentTypeTest.scala
+++ b/core/src/test/scala/org/scalatra/ContentTypeTest.scala
@@ -90,7 +90,7 @@ class ContentTypeTest extends ScalatraFunSuite with BeforeAndAfterAll {
   val system = ActorSystem()
   implicit val timeout: Timeout = 5.seconds
 
-  override def afterAll = system.terminate()
+  override def afterAll() = system.terminate()
 
   val servletHolder = new ServletHolder(new ContentTypeTestServlet(system))
   servletHolder.setInitOrder(1) // force load on startup

--- a/core/src/test/scala/org/scalatra/FlashMapTest.scala
+++ b/core/src/test/scala/org/scalatra/FlashMapTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 class FlashMapTest extends AnyFunSuite with Matchers with BeforeAndAfterEach {
   var flash: FlashMap = _
 
-  override def beforeEach = flash = new FlashMap()
+  override def beforeEach() = flash = new FlashMap()
 
   test("values are visible immmediately") {
     flash("foo") = "bar"

--- a/scalate/src/test/scala/org/scalatra/scalate/ScalateFuturesSupportSpec.scala
+++ b/scalate/src/test/scala/org/scalatra/scalate/ScalateFuturesSupportSpec.scala
@@ -176,7 +176,7 @@ class ScalateFuturesSupportSpec extends MutableScalatraSpec {
   val pool = DaemonThreadFactory.newPool()
   addServlet(new ScalateFuturesSupportServlet(pool), "/*")
 
-  override def afterAll = {
+  override def afterAll() = {
     super.afterAll()
     pool.shutdown()
   }
@@ -301,7 +301,7 @@ class ScalateFuturesWithErrorHandlerSupportSpec extends MutableScalatraSpec {
   val pool = DaemonThreadFactory.newPool()
   addServlet(new ScalateFuturesWithErrorHandlerSupportServlet(pool), "/*")
 
-  override def afterAll = {
+  override def afterAll() = {
     super.afterAll()
     pool.shutdown()
   }

--- a/specs2/src/main/scala/org/scalatra/test/specs2/BaseScalatraSpec.scala
+++ b/specs2/src/main/scala/org/scalatra/test/specs2/BaseScalatraSpec.scala
@@ -10,6 +10,6 @@ import org.specs2.specification.BeforeAfterAll
  * ScalatraSpec or MutableScalatraSpec.
  */
 trait BaseScalatraSpec extends BeforeAfterAll with ScalatraTests {
-  def beforeAll = start()
-  def afterAll = stop()
+  def beforeAll() = start()
+  def afterAll() = stop()
 }

--- a/test/src/test/scala/org/scalatra/test/EmbeddedJettyContainerSpec.scala
+++ b/test/src/test/scala/org/scalatra/test/EmbeddedJettyContainerSpec.scala
@@ -10,8 +10,8 @@ class EmbeddedJettyContainerSpec extends SpecificationLike
   with HttpComponentsClient
   with BeforeAfterAll {
 
-  def beforeAll = start()
-  def afterAll = stop()
+  def beforeAll() = start()
+  def afterAll() = stop()
 
   addServlet(new HttpServlet {
     override def doGet(req: HttpServletRequest, res: HttpServletResponse) = {

--- a/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
+++ b/test/src/test/scala/org/scalatra/test/HttpComponentsClientSpec.scala
@@ -15,8 +15,8 @@ class HttpComponentsClientSpec
   with EmbeddedJettyContainer
   with BeforeAfterAll {
 
-  def beforeAll = start()
-  def afterAll = stop()
+  def beforeAll() = start()
+  def afterAll() = stop()
 
   addServlet(new HttpServlet {
     override def service(req: HttpServletRequest, resp: HttpServletResponse): Unit = {


### PR DESCRIPTION
If there are parentheses in the original method declaration,
there should be parentheses in the inherited method declaration.