### PR TITLE
Use tuple instead of Array for variable assignment

### DIFF
--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -36,7 +36,7 @@ case class HttpComponentsClientResponse(res: HttpResponse) extends ClientRespons
 
   def headers = {
     res.getAllHeaders.foldLeft(Map[String, Seq[String]]()) { (hmap, header) =>
-      val Array(name, value) = Array(header.getName, header.getValue)
+      val (name, value) = (header.getName, header.getValue)
       val values = hmap.getOrElse(name, Seq())
 
       hmap + (name -> (values :+ value))


### PR DESCRIPTION
In the case of Array, since the number of variables
returned does not always match (the compiler will issue a warning message)