### PR TITLE
fixed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target/
 .DS_Store
 .ensime
 .target
+.bsp
 
 # paulp script #
 /.lib/


### PR DESCRIPTION
added .bsp ... for Build Server Protocol

The bsp (build server protocol) supported in sbt 1.4.x creates
a unique temporary directory, but this directory does not need
to be shared, so it should not be managed by git.