### PR TITLE
Fix RichRequest.remoteAddress to return the first address of X-Forwarded-For header

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
@@ -4,8 +4,9 @@ package servlet
 import java.io.InputStream
 import java.net.URI
 import java.util.Locale
-import javax.servlet.http.HttpServletRequest
 
+import javax.servlet.http.HttpServletRequest
+import org.apache.commons.lang3.StringUtils
 import org.scalatra.util.RicherString._
 import org.scalatra.util.MultiMapHeadView
 
@@ -253,7 +254,7 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
    * This takes the load balancing header X-Forwarded-For into account
    * @return the client ip address
    */
-  def remoteAddress: String = header("X-FORWARDED-FOR").flatMap(_.blankOption) getOrElse r.getRemoteAddr
+  def remoteAddress: String = header("X-FORWARDED-FOR").flatMap(_.split(",").map(_.trim).filterNot(StringUtils.isBlank).headOption).getOrElse(r.getRemoteAddr)
 
   def locale: Locale = r.getLocale
 

--- a/core/src/test/scala/org/scalatra/servlet/RichRequestTest.scala
+++ b/core/src/test/scala/org/scalatra/servlet/RichRequestTest.scala
@@ -52,11 +52,37 @@ class RichRequestTest extends AnyFunSuite with Matchers {
     }
   }
 
-  def createStubRequestWithServletInputStreamThrowsIOException(): HttpServletRequest = {
+  private def createStubRequestWithServletInputStreamThrowsIOException(): HttpServletRequest = {
     val request = mock(classOf[HttpServletRequest])
     when(request.getInputStream).thenReturn(new ServletInputStreamThrowsIOException)
 
     request
+  }
+
+  test("remoteAddress for single address in X-Forwarded-For header") {
+    val request = mock(classOf[HttpServletRequest])
+    when(request.getHeader("X-FORWARDED-FOR")).thenReturn("1.2.3.4")
+    request.remoteAddress should equal("1.2.3.4")
+  }
+
+  test("remoteAddress for multiple addresses in X-Forwarded-For header") {
+    val request = mock(classOf[HttpServletRequest])
+    when(request.getHeader("X-FORWARDED-FOR")).thenReturn("1.2.3.4, 5.6.7.8")
+    request.remoteAddress should equal("1.2.3.4")
+  }
+
+  test("remoteAddress without X-Forwarded-For header") {
+    val request = mock(classOf[HttpServletRequest])
+    when(request.getHeader("X-FORWARDED-FOR")).thenReturn(null)
+    when(request.getRemoteAddr).thenReturn("0.0.0.0")
+    request.remoteAddress should equal("0.0.0.0")
+  }
+
+  test("remoteAddress for blank X-Forwarded-For header") {
+    val request = mock(classOf[HttpServletRequest])
+    when(request.getHeader("X-FORWARDED-FOR")).thenReturn("")
+    when(request.getRemoteAddr).thenReturn("0.0.0.0")
+    request.remoteAddress should equal("0.0.0.0")
   }
 }
 


### PR DESCRIPTION
Fixes #1032