### PR TITLE
fix warning. add explicit `toDouble` call

### DIFF
--- a/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
+++ b/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
@@ -50,7 +50,7 @@ trait UrlCodingUtils {
 
   def urlEncode(toEncode: String, charset: Charset = StandardCharsets.UTF_8, spaceIsPlus: Boolean = false, toSkip: BitSet = toSkip): String = {
     val in = charset.encode(ensureUppercasedEncodings(toEncode))
-    val out = CharBuffer.allocate((in.remaining() * 3).ceil.toInt)
+    val out = CharBuffer.allocate((in.remaining() * 3).toDouble.ceil.toInt)
     while (in.hasRemaining) {
       val b = in.get() & 0xFF
       if (toSkip.contains(b)) {


### PR DESCRIPTION
prepare Scala 3

```
 [warn] /home/runner/work/scalatra/scalatra/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala:53:51: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
 [warn]     val out = CharBuffer.allocate((in.remaining() * 3).ceil.toInt)
 [warn]                                                   ^
```