### PR TITLE
add parentheses for lambda params

### DIFF
--- a/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
+++ b/atmosphere/src/main/scala/org/atmosphere/cpr/broadcaster_configs.scala
@@ -34,7 +34,7 @@ sealed case class ScalatraBroadcasterConfig(
  */
 sealed case class RedisScalatraBroadcasterConfig(uri: URI = URI.create("redis://127.0.0.1:6379"), auth: Option[String] = None) extends BroadcasterConf {
   final def broadcasterClass = classOf[RedisScalatraBroadcaster]
-  final def extraSetup = { b: Broadcaster =>
+  final def extraSetup = { (b: Broadcaster) =>
     auth.foreach(b.asInstanceOf[RedisScalatraBroadcaster].setAuth(_))
   }
 }

--- a/scalate/src/main/scala/org/scalatra/scalate/ScalateUrlGeneratorSupport.scala
+++ b/scalate/src/main/scala/org/scalatra/scalate/ScalateUrlGeneratorSupport.scala
@@ -58,7 +58,7 @@ trait ScalateUrlGeneratorSupport extends ScalateSupport {
         val pathForCurrentRequest = request.getServletPath
         val mappingsForServletContainingRoute = servletContext.getServletRegistration(servletName).getMappings.asScala
         val pathForServletContainingRoute = mappingsForServletContainingRoute.headOption.getOrElse("")
-        val pathReplacingFn = { req: HttpServletRequest =>
+        val pathReplacingFn = { (req: HttpServletRequest) =>
           route.contextPath(req)
             .replaceFirst(
               pathForCurrentRequest,


### PR DESCRIPTION
prepare Scala 3

```
scala> List(1).map{ a => a }
val res0: List[Int] = List(1)

scala> List(1).map{ a: Int => a }
1 |List(1).map{ a: Int => a }
  |                    ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.

scala> List(1).map{ (a: Int) => a }
val res1: List[Int] = List(1)
```