### PR TITLE
add explicit type for Array

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
@@ -221,7 +221,7 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
    * value of the map is the empty sequence.
    */
   def multiCookies: MultiParams = {
-    Option(r.getCookies).getOrElse(Array()).toSeq.
+    Option(r.getCookies).getOrElse(Array.empty[javax.servlet.http.Cookie]).toSeq.
       groupBy { _.getName }.
       transform { case (k, v) => v map { _.getValue } }.
       withDefaultValue(Seq.empty)


### PR DESCRIPTION
prepare Scala 3

```
scala> val a: Array[Int] = Option(Array[Int](3)).getOrElse(Array.empty)
val a: Array[Int] = Array(3)

scala> val a = Option(Array[Int](3)).getOrElse(Array.empty)
1 |val a = Option(Array[Int](3)).getOrElse(Array.empty)
  |                                                   ^
  |                                         No ClassTag available for Nothing

scala> val a = Option(Array[Int](3)).getOrElse(Array.empty[Int])                                                                           
val a: Array[Int] = Array(3)

scala> val a = Option(Array[Int](3)).getOrElse(Array())                                                                          
1 |val a = Option(Array[Int](3)).getOrElse(Array())
  |                                               ^
  |                                         No ClassTag available for Nothing
```