### PR TITLE
remove "-language:reflectiveCalls" option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val scalatraSettings = Seq(
     "-feature",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-language:reflectiveCalls",
     "-language:existentials"
   ),
   manifestSetting,


### PR DESCRIPTION
avoid `Unused import` warning in Scala 2