### PR TITLE
Rollback scala-xml to 1.3.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object Dependencies {
   lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "2.0.0" cross CrossVersion.for3Use2_13
-  lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "2.0.1"
+  lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "1.3.0" cross CrossVersion.for3Use2_13
   lazy val akkaActor                =  "com.typesafe.akka"       %% "akka-actor"                 % akkaVersion cross CrossVersion.for3Use2_13
   lazy val akkaTestkit              =  "com.typesafe.akka"       %% "akka-testkit"               % akkaVersion cross CrossVersion.for3Use2_13
   lazy val atmosphereRuntime        =  "org.atmosphere"          %  "atmosphere-runtime"         % "2.7.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "2.0.0" cross CrossVersion.for3Use2_13
+  lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "1.1.2" cross CrossVersion.for3Use2_13
   lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "1.3.0" cross CrossVersion.for3Use2_13
   lazy val akkaActor                =  "com.typesafe.akka"       %% "akka-actor"                 % akkaVersion cross CrossVersion.for3Use2_13
   lazy val akkaTestkit              =  "com.typesafe.akka"       %% "akka-testkit"               % akkaVersion cross CrossVersion.for3Use2_13
@@ -43,7 +43,7 @@ object Dependencies {
                                          "funsuite",
                                          "shouldmatchers",
                                          "mustmatchers",
-                                       ).map(x => "org.scalatest" %% s"scalatest-$x" % scalatestVersion)
+                                       ).map(x => "org.scalatest" %% s"scalatest-$x" % scalatestVersion cross CrossVersion.for3Use2_13)
   lazy val servletApi               =  "javax.servlet"           %  "javax.servlet-api"          % "3.1.0"
   lazy val slf4jApi                 =  "org.slf4j"               %  "slf4j-api"                  % "1.7.32"
   lazy val specs2                   =  Seq(
@@ -62,7 +62,7 @@ object Dependencies {
   private val httpcomponentsVersion   = "4.5.6"
   private val jettyVersion            = "9.4.43.v20210629"
   private val json4sVersion           = "4.0.1"
-  private val scalateVersion          = "1.9.7"
-  private val specs2Version           = "4.12.3"
+  private val scalateVersion          = "1.9.6"
+  private val specs2Version           = "4.10.6"
   private val scalatestVersion        = "3.2.9"
 }


### PR DESCRIPTION
Since Scalate and Twirl still use scala-xml 1.x, sbt reports the following error if we upgrade Scalatra to 2.8.0 in applications:
```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang.modules:scala-xml_2.13:2.0.1 (early-semver) is selected over {1.2.0, 2.0.0}
[error] 	    +- org.scalatra:scalatra_2.13:2.8.0                   (depends on 2.0.1)
[error] 	    +- org.json4s:json4s-xml_2.13:4.0.1                   (depends on 2.0.0)
[error] 	    +- com.typesafe.play:twirl-api_2.13:1.5.1             (depends on 1.2.0)
[error] 
[error] 
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at sbt.internal.LibraryManagement$.resolve$1(LibraryManagement.scala:89)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$12(LibraryManagement.scala:133)
[error] 	at sbt.util.Tracked$.$anonfun$lastOutput$1(Tracked.scala:73)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$20(LibraryManagement.scala:146)
[error] 	at scala.util.control.Exception$Catch.apply(Exception.scala:228)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11(LibraryManagement.scala:146)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11$adapted(LibraryManagement.scala:127)
[error] 	at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:219)
[error] 	at sbt.internal.LibraryManagement$.cachedUpdate(LibraryManagement.scala:160)
[error] 	at sbt.Classpaths$.$anonfun$updateTask0$1(Defaults.scala:3678)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error] 	at sbt.Execute.work(Execute.scala:291)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang.modules:scala-xml_2.13:2.0.1 (early-semver) is selected over {1.2.0, 2.0.0}
[error] 	    +- org.scalatra:scalatra_2.13:2.8.0                   (depends on 2.0.1)
[error] 	    +- org.json4s:json4s-xml_2.13:4.0.1                   (depends on 2.0.0)
[error] 	    +- com.typesafe.play:twirl-api_2.13:1.5.1             (depends on 1.2.0)
[error] 
[error] 
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```
I would rollback scala-xml to 1.3.0 and release Scalara 2.8.1.