### PR TITLE
fix warnings

### DIFF
--- a/auth/src/test/scala/org/scalatra/auth/ScentrySpec.scala
+++ b/auth/src/test/scala/org/scalatra/auth/ScentrySpec.scala
@@ -20,12 +20,12 @@ object ScentrySpec extends Specification with Mockito {
       private[this] val sessionMap = scala.collection.mutable.HashMap[String, Any](Scentry.scentryAuthKey -> "6789")
       val mockSession = smartMock[HttpSession]
       override def session(implicit request: HttpServletRequest) = mockSession
-      mockSession.getAttribute(anyString) answers { k: Any => sessionMap.getOrElse(k.asInstanceOf[String], null).asInstanceOf[AnyRef] }
+      mockSession.getAttribute(anyString) answers { (k: Any) => sessionMap.getOrElse(k.asInstanceOf[String], null).asInstanceOf[AnyRef] }
       mockSession.setAttribute(anyString, anyObject) answers { (kv, wtfIsThis) =>
         val Array(k: String, v: Any) = kv
         sessionMap(k) = v
       }
-      mockSession.invalidate() answers { _: Any =>
+      mockSession.invalidate() answers { (_: Any) =>
         invalidateCalled = true
         sessionMap.clear()
       }


### PR DESCRIPTION
```
[warn] -- Migration Warning: /home/runner/work/scalatra/scalatra/auth/src/test/scala/org/scalatra/auth/ScentrySpec.scala:23:59 
[warn] 23 |      mockSession.getAttribute(anyString) answers { k: Any => sessionMap.getOrElse(k.asInstanceOf[String], null).asInstanceOf[AnyRef] }
[warn]    |                                                           ^
[warn]    |parentheses are required around the parameter of a lambda
[warn]    |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
[warn] -- Migration Warning: /home/runner/work/scalatra/scalatra/auth/src/test/scala/org/scalatra/auth/ScentrySpec.scala:28:48 
[warn] 28 |      mockSession.invalidate() answers { _: Any =>
[warn]    |                                                ^
[warn]    |parentheses are required around the parameter of a lambda
```