### PR TITLE
Revert "Downgrade scala-xml in Scala2 following twirl"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ lazy val scalatraCore = Project(
       jUniversalChardet,
       commonsText,
       parserCombinators,
-      xml.value,
+      xml,
       akkaActor % "test",
       akkaTestkit % "test"
     ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val xml                      =  Def.setting("org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion.value)
   lazy val parserCombinators        =  "org.scala-lang.modules"  %% "scala-parser-combinators"   % "2.0.0" cross CrossVersion.for3Use2_13
+  lazy val xml                      =  "org.scala-lang.modules"  %% "scala-xml"                  % "2.0.1"
   lazy val akkaActor                =  "com.typesafe.akka"       %% "akka-actor"                 % akkaVersion cross CrossVersion.for3Use2_13
   lazy val akkaTestkit              =  "com.typesafe.akka"       %% "akka-testkit"               % akkaVersion cross CrossVersion.for3Use2_13
   lazy val atmosphereRuntime        =  "org.atmosphere"          %  "atmosphere-runtime"         % "2.7.2"
@@ -65,10 +65,4 @@ object Dependencies {
   private val scalateVersion          = "1.9.7"
   private val specs2Version           = "4.12.3"
   private val scalatestVersion        = "3.2.9"
-  private val scalaXmlVersion         = Def.setting(
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _)) => "2.0.1"
-      case _            => "1.2.0"
-    }
-  )
 }


### PR DESCRIPTION
Reverts scalatra/scalatra#1286

I found that this causes another **scala-xml** version conflict with **scalatra-json** that has a dependency to **json4s-xml**. It's better to apply a workaround (adding `libraryDependencySchemes` or `evictionErrorLevel` to the application's build configuration) when we use **twirl** than when we use **scalatra-json**.