### PR TITLE
Exclude scala-xml from json4s-xml

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,10 @@ object Dependencies {
   lazy val json4sExt                =  "org.json4s"              %% "json4s-ext"                 % json4sVersion cross CrossVersion.for3Use2_13
   lazy val json4sJackson            =  "org.json4s"              %% "json4s-jackson"             % json4sVersion cross CrossVersion.for3Use2_13
   lazy val json4sNative             =  "org.json4s"              %% "json4s-native"              % json4sVersion cross CrossVersion.for3Use2_13
-  lazy val json4sXml                =  "org.json4s"              %% "json4s-xml"                 % json4sVersion cross CrossVersion.for3Use2_13
+  lazy val json4sXml                =  "org.json4s"              %% "json4s-xml"                 % json4sVersion cross CrossVersion.for3Use2_13 excludeAll (
+    ExclusionRule(organization = "org.scala-lang.modules", name = "scala-xml_2.12"),
+    ExclusionRule(organization = "org.scala-lang.modules", name = "scala-xml_2.13")
+  )
   lazy val junit                    =  "junit"                   %  "junit"                      % "4.13.2"
   lazy val scalatestJunit           =  "org.scalatestplus"       %% "junit-4-13"                 % "3.2.9.0"
   lazy val jUniversalChardet        =  "com.github.albfernandez" %  "juniversalchardet"          % "2.4.0"


### PR DESCRIPTION
Another workaround to solve scala-xml version conflict other than https://github.com/scalatra/scalatra/pull/1287