### PR TITLE
removed scalate module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,6 @@ lazy val scalatraProject = Project(
     scalatraCore,
     scalatraAuth,
     scalatraForms,
-    scalatraScalate,
     scalatraTwirl,
     scalatraJson,
     scalatraTest,
@@ -134,23 +133,6 @@ lazy val scalatraAuth = Project(
     description := "Scalatra authentication module"
   )
 ) dependsOn(scalatraCore % "compile;test->test;provided->provided")
-
-lazy val scalatraScalate = Project(
-  id = "scalatra-scalate",
-  base = file("scalate")).settings(
-    scalatraSettings ++ Seq(
-    libraryDependencies += scalate,
-    Test / test := {
-      if (scalaBinaryVersion.value == "3") {
-        // scalate does not work with Scala 3
-        ()
-      } else {
-        (Test / test).value
-      }
-    },
-    description := "Scalate integration with Scalatra"
-  )
-) dependsOn(scalatraCore  % "compile;test->test;provided->provided")
 
 lazy val scalatraTwirl = Project(
   id = "scalatra-twirl",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,6 @@ object Dependencies {
   lazy val jUniversalChardet        =  "com.github.albfernandez" %  "juniversalchardet"          % "2.4.0"
   lazy val logbackClassic           =  "ch.qos.logback"          %  "logback-classic"            % "1.2.6"
   lazy val mockitoAll               =  "org.mockito"             %  "mockito-core"               % "4.0.0"
-  lazy val scalate                  =  "org.scalatra.scalate"    %% "scalate-core"               % scalateVersion cross CrossVersion.for3Use2_13
   lazy val scalatest                =  Seq(
                                          "funspec",
                                          "wordspec",
@@ -53,7 +52,6 @@ object Dependencies {
   private val httpcomponentsVersion   = "4.5.6"
   private val jettyVersion            = "9.4.44.v20210927"
   private val json4sVersion           = "4.0.3"
-  private val scalateVersion          = "1.9.7"
   private val specs2Version           = "4.13.0"
   private val scalatestVersion        = "3.2.10"
 }


### PR DESCRIPTION
Scalate is strongly dependent on the Scala2 compiler,
which will be an obstacle for future Scala3 support.

The formatting went wrong, so I reworked the PR.