### PR TITLE
Update Scala 3 specs2 setting

### DIFF
--- a/auth/src/test/scala/org/scalatra/auth/strategy/BasicAuthStrategySpec.scala
+++ b/auth/src/test/scala/org/scalatra/auth/strategy/BasicAuthStrategySpec.scala
@@ -3,13 +3,12 @@ package auth
 package strategy
 
 import javax.servlet.http.HttpServletRequest
-
+import org.mockito.Mockito
 import org.scalatra.test.specs2._
-import org.specs2.mock.Mockito
 
-class BasicAuthStrategySpec extends MutableScalatraSpec with Mockito {
+class BasicAuthStrategySpec extends MutableScalatraSpec {
   "params on a request with no auth headers" should {
-    val httpRequest = mock[HttpServletRequest]
+    val httpRequest = Mockito.mock(classOf[HttpServletRequest])
     val basicAuthRequest = new BasicAuthStrategy.BasicAuthRequest(httpRequest)
     "return None" in { // https://github.com/scalatra/scalatra/issues/143
       basicAuthRequest.params must_== None

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ lazy val scalatraSettings = Seq(
     if (scalaBinaryVersion.value == "3") {
       Seq(
         Tests.Exclude(Set(
-          "org.scalatra.test.specs2.ScalatraSpecSpec",
           "org.scalatra.swagger.ModelSpec",
           "org.scalatra.swagger.SwaggerSpec2",
           "org.scalatra.swagger.ModelCollectionSpec",
@@ -76,14 +75,6 @@ lazy val scalatraProject = Project(
   base = file(".")).settings(
     scalatraSettings ++ Seq(
     name := "scalatra-unidoc",
-    ScalaUnidoc / unidoc / unidocProjectFilter := {
-      if (scalaBinaryVersion.value == "3") {
-        // TODO enable
-        inAnyProject -- inProjects(scalatraSpecs2)
-      } else {
-        (ScalaUnidoc / unidoc / unidocProjectFilter).value
-      }
-    },
     artifacts := Classpaths.artifactDefs(Seq(Compile / packageDoc, Compile / makePom)).value,
     packagedArtifacts := Classpaths.packaged(Seq(Compile / packageDoc, Compile / makePom)).value,
     description := "A tiny, Sinatra-like web framework for Scala",
@@ -221,13 +212,6 @@ lazy val scalatraSpecs2 = Project(
   base = file("specs2")).settings(
     scalatraSettings ++ Seq(
     libraryDependencies ++= specs2,
-    Test / scalacOptions ++= {
-      if (scalaBinaryVersion.value == "3") {
-        Seq("-Xignore-scala2-macros")
-      } else {
-        Nil
-      }
-    },
     description := "Specs2 support for the Scalatra test framework"
   )
 ) dependsOn(scalatraTest % "compile;test->test;provided->provided")

--- a/core/src/test/scala/org/scalatra/XsrfTokenSpec.scala
+++ b/core/src/test/scala/org/scalatra/XsrfTokenSpec.scala
@@ -32,7 +32,7 @@ object XsrfTokenSpec extends MutableScalatraSpec {
   "the get request should include the CSRF token" in {
     get("/renderForm") {
       tokenFromCookie must not be null
-      tokenFromCookie must not be empty
+      tokenFromCookie must not be ""
       body must beMatching("GO")
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,9 +39,8 @@ object Dependencies {
   lazy val slf4jApi                 =  "org.slf4j"               %  "slf4j-api"                  % "1.7.36"
   lazy val specs2                   =  Seq(
                                        "org.specs2"              %% "specs2-core",
-                                       "org.specs2"              %% "specs2-mock",
                                        "org.specs2"              %% "specs2-matcher-extra"
-                                       ).map(_ % specs2Version cross CrossVersion.for3Use2_13)
+                                       ).map(_ % specs2Version)
   lazy val metricsScala             =  "nl.grons"                %% "metrics4-scala"             % "4.2.8"
   lazy val metricsServlets          =  "io.dropwizard.metrics"   %  "metrics-servlets"           % "4.2.9"
   lazy val metricsServlet           =  "io.dropwizard.metrics"   %  "metrics-servlet"            % "4.2.9"


### PR DESCRIPTION
https://twitter.com/specs2org/status/1505839807574032384

> There is a cross-compiled version of specs2 for Scala 2.12, 2.13, 3.1 if you need to cross-compile your libraries to help with the Scala 2->3 migration:

🎉 

- remove `specs2-mock` because does not available for Scala 3
- enable Scala 3 unidoc
- remove `-Xignore-scala2-macros` option