### PR TITLE
Removed unused import

### DIFF
--- a/metrics/src/main/scala/org/scalatra/metrics/MetricsSupport.scala
+++ b/metrics/src/main/scala/org/scalatra/metrics/MetricsSupport.scala
@@ -2,10 +2,9 @@ package org.scalatra.metrics
 
 import java.util.concurrent.Callable
 
-import com.codahale.metrics._
 import nl.grons.metrics4.scala._
 
-trait MetricsSupport extends nl.grons.metrics4.scala.InstrumentedBuilder with MetricsBootstrap {
+trait MetricsSupport extends InstrumentedBuilder with MetricsBootstrap {
 
   def metricName(name: String) = MetricName(name)
 


### PR DESCRIPTION
to reduce unnecessary import warnings

This is a correction that was overlooked when creating the following PR
https://github.com/scalatra/scalatra/pull/1389