### PR TITLE
Replaced from `toIterator` to `.iterator`

### DIFF
--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
@@ -81,7 +81,7 @@ object Reflector {
       def properties: Seq[PropertyDescriptor] = {
         def fields(clazz: Class[_]): List[PropertyDescriptor] = {
           val lb = new ArrayBuffer[PropertyDescriptor]()
-          val ls = clazz.getDeclaredFields.toIterator
+          val ls = clazz.getDeclaredFields.iterator
           while (ls.hasNext) {
             val f = ls.next()
             val mod = f.getModifiers


### PR DESCRIPTION
`toIterator` is deprecated since 2.13.0