### PR TITLE
Deprecate org.scalatra.util.using()

### DIFF
--- a/core/src/main/scala/org/scalatra/ScalatraBase.scala
+++ b/core/src/main/scala/org/scalatra/ScalatraBase.scala
@@ -442,13 +442,14 @@ trait ScalatraBase
       if (contentType != null && contentType.startsWith("text")) response.setCharacterEncoding(FileCharset(bytes).name)
       response.outputStream.write(bytes)
     case is: java.io.InputStream =>
-      using(is) {
-        util.io.copy(_, response.outputStream)
-      }
+      util.io.copy(is, response.outputStream)
     case file: File =>
       if (contentType startsWith "text") response.setCharacterEncoding(FileCharset(file).name)
-      using(new FileInputStream(file)) {
-        in => zeroCopy(in, response.outputStream)
+      val in = new FileInputStream(file)
+      try {
+        zeroCopy(in, response.outputStream)
+      } finally {
+        in.close()
       }
     // If an action returns Unit, it assumes responsibility for the response
     case _: Unit | null =>

--- a/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
+++ b/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
@@ -272,8 +272,11 @@ case class FileItem(part: Part) {
   def getCharset: Option[String] = charset.orElse(null)
 
   def write(file: File): Unit = {
-    using(new FileOutputStream(file)) { out =>
+    val out = new FileOutputStream(file)
+    try {
       io.copy(getInputStream, out)
+    } finally {
+      out.close()
     }
   }
 

--- a/core/src/main/scala/org/scalatra/util/io/package.scala
+++ b/core/src/main/scala/org/scalatra/util/io/package.scala
@@ -2,7 +2,6 @@ package org.scalatra.util
 
 import java.io._
 import java.nio.channels.Channels
-
 import scala.annotation.tailrec
 import scala.language.reflectiveCalls
 
@@ -19,6 +18,7 @@ package object io {
    * @param closeable the closeable resource
    * @param f the block
    */
+  @deprecated("Use Using.resource() since Scala 2.13", "2.8.2")
   def using[A, B <: { def close(): Unit }](closeable: B)(f: B => A): A = {
     try {
       f(closeable)
@@ -38,8 +38,9 @@ package object io {
    * @param bufferSize the size of buffer to use for each read
    */
   def copy(in: InputStream, out: OutputStream, bufferSize: Int = 4096): Unit = {
-    using(in) { in =>
+    try {
       val buf = new Array[Byte](bufferSize)
+
       @tailrec
       def loop(): Unit = {
         val n = in.read(buf)
@@ -48,7 +49,10 @@ package object io {
           loop()
         }
       }
+
       loop()
+    } finally {
+      in.close()
     }
   }
 


### PR DESCRIPTION
`org.scalatra.util.io.using()` causes the following error on Java 11 for an InputStream created by `ClassLoader.getResourceAsStream()`:

```
java.lang.reflect.InaccessibleObjectException: Unable to make public void sun.net.www.protocol.jar.JarURLConnection$JarURLInputStream.close() throws java.io.IOException accessible: module java.base does not "opens sun.net.www.protocol.jar" to unnamed module @67f639d3
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
        at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
        at scala.reflect.package$.ensureAccessible(package.scala:62)
        at scala.runtime.ScalaRunTime$.ensureAccessible(ScalaRunTime.scala:153)
        at org.scalatra.util.io.package$.reflMethod$Method1(package.scala:27)
        at org.scalatra.util.io.package$.using(package.scala:27)
        ...
```
It shouldn't be deprecated and also shouldn't be used inside Scalatra especially at places where take `InputStream` from user code.