### PR TITLE
Support custom HttpComponentsClient RequestConfig

### DIFF
--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -100,6 +100,13 @@ trait HttpComponentsClient extends Client {
     builder.build()
   }
 
+  /**
+   * Can be overridden to, eg: `setNormalizeUri(false)` if using HttpComponents HttpClient v4.5.8
+   * or later.
+   */
+  protected val httpComponentsRequestConfig: RequestConfig =
+    RequestConfig.custom().setCookieSpec("compatibility").build()
+
   private def attachHeaders(req: HttpRequestBase, headers: Iterable[(String, String)]): Unit = {
     headers.foreach { case (name, value) => req.addHeader(name, value) }
   }
@@ -116,7 +123,7 @@ trait HttpComponentsClient extends Client {
       case "PATCH" => new HttpPatch(url)
     }
 
-    req.setConfig(RequestConfig.custom().setCookieSpec("compatibility").build())
+    req.setConfig(httpComponentsRequestConfig)
 
     req
   }


### PR DESCRIPTION
The scalatra-test framework offers the `HttpComponentsClient` trait to help write tests that exercise Scalatra endpoints. The trait uses the Apache HttpComponents HttpClient library.

**Unfortunately, there are problems with later versions of the HttpComponents HttpClient that can only be resolved by setting fields on `org.apache.http.client.config.RequestConfig`.** For consumers of Scalatra, it's difficult to control what `RequestConfig` is used _unless_ it's exposed in a non-private field that can be overridden.

The specific problem I'm experiencing with HttpComponents HttpClient relates to URIBuilder normalization. The description of https://issues.apache.org/jira/browse/HTTPCLIENT-1983 explains it pretty well:

> In 4.5.7, the behavior of URIBuilder changed in order to address HTTPCLIENT-1960. Since that version was released, I have seen a concerning number of users complain that this change has broken their code (see issue links). In 4.5.8, as a result of HTTPCLIENT-1968, an option was added to allow users to opt in to the old behavior, but the new behavior is what they will get by default.

The new `URIBuilder` behaviour remains default in the latest versions of HttpComponents HttpClient, but unfortunately it's problematic for me (I am one of those 'concerning number of users' mentioned above!) - I would like to disable it, but can only do so by setting the new `RequestConfig.setNormalizeUri()` method added with HttpComponents HttpClient v4.5.8 - and I can only do that if I have access to the config used by Scalatra's `HttpComponentsClient`.

Note that many libraries - like the AWS SDK - are now pulling in newer versions of the Apache HttpComponents HttpClient library, so even though Scalatra currently builds with [v4.5.6](https://github.com/scalatra/scalatra/blob/59e27dd891f8f3b54e5f94e1c474564a3aa80392/project/Dependencies.scala#L49), users of Scalatra may find that they are using the new, problematic versions of the library. It's possible that they will _want_ the new `URIBuilder` behaviour - or likely not - but in either case they can't control it without the field access exposed with this change.

cc @magnolia-k 