### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,7 @@
 ## Scalatra ![Scala CI](https://github.com/scalatra/scalatra/workflows/build/badge.svg?branch=2.7.x)
 
 [![Join the chat at https://gitter.im/scalatra/scalatra](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scalatra/scalatra?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![scalatra Scala version support](https://index.scala-lang.org/scalatra/scalatra/scalatra/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalatra/scalatra/scalatra)
 
 Scalatra is a tiny, [Sinatra](http://www.sinatrarb.com/)-like web framework for
 [Scala](http://www.scala-lang.org/).


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `scalatra` (and what the latest `scalatra` version is for each of those Scala versions), so it provides a bit more information than a Maven badge:

[![scalatra Scala version support](https://index.scala-lang.org/scalatra/scalatra/scalatra/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scalatra/scalatra/scalatra)

More details on the badge format: https://github.com/scalacenter/scaladex/pull/660