### PR TITLE
Changed URL generation method

### DIFF
--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -53,6 +53,10 @@ trait HttpComponentsClient extends Client {
     _cookieStore.withValue(new BasicCookieStore) { f }
   }
 
+  // non-empty path must begin with a slash
+  private def buildUrl(baseUrl: String, path: String): String =
+    if (!path.startsWith("/")) baseUrl + "/" + path else baseUrl + path
+
   def submit[A](
     method: String,
     path: String,
@@ -63,9 +67,9 @@ trait HttpComponentsClient extends Client {
       val client = createClient
       val queryString = toQueryString(queryParams)
       val url = if (queryString == "")
-        "%s/%s".format(baseUrl, path)
+        buildUrl(baseUrl, path)
       else
-        "%s/%s?%s".format(baseUrl, path, queryString)
+        s"${buildUrl(baseUrl, path)}?$queryString"
 
       val req = createMethod(method.toUpperCase, url)
       attachBody(req, body)
@@ -82,8 +86,7 @@ trait HttpComponentsClient extends Client {
     files: Iterable[(String, Any)])(f: => A): A =
     {
       val client = createClient
-      val url = "%s/%s".format(baseUrl, path)
-      val req = createMethod(method.toUpperCase, url)
+      val req = createMethod(method.toUpperCase, buildUrl(baseUrl, path))
 
       attachMultipartBody(req, params, files)
       attachHeaders(req, headers)


### PR DESCRIPTION
In the submit method, the code always adds a slash between the authority and the path in the URL generation.

Therefore, when a path beginning with a slash is passed to the HTTP method, a path beginning with a double slash is always generated.

This double slash was normalized in apache http client 4.x, so it did not become apparent. However, in apache http client 5.x, the double slash is not normalized, so it may be judged as an invalid URL in future updates of the library.

Therefore, the code was changed to determine whether the HTTP method path begins with a slash or not and generate the correct URL.

Although a valid path should start with a slash, for backward compatibility, it is treated as a valid path even if it does not start with a slash.