### PR TITLE
removed unnecessary CookieSpec settings

### DIFF
--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -108,7 +108,7 @@ trait HttpComponentsClient extends Client {
    * or later.
    */
   protected val httpComponentsRequestConfig: RequestConfig =
-    RequestConfig.custom().setCookieSpec("compatibility").build()
+    RequestConfig.custom().build()
 
   private def attachHeaders(req: HttpRequestBase, headers: Iterable[(String, String)]): Unit = {
     headers.foreach { case (name, value) => req.addHeader(name, value) }


### PR DESCRIPTION
"compatibility" is currently invalid, is an invalid setting, and is unnecessary. (If not set, it will be in StandardCookieSpec.STRICT mode)