### PR TITLE
Removed sbt-updates plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,5 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 addSbtPlugin("org.xerial.sbt"       % "sbt-sonatype"         % "3.9.15")
 addSbtPlugin("org.scalariform"      % "sbt-scalariform"      % "1.8.3")
-addSbtPlugin("com.timushev.sbt"     % "sbt-updates"          % "0.6.4")
-addSbtPlugin("com.github.sbt"         % "sbt-pgp"              % "2.2.1")
+addSbtPlugin("com.github.sbt"       % "sbt-pgp"              % "2.2.1")
 addSbtPlugin("com.github.sbt"       % "sbt-unidoc"           % "0.5.0")


### PR DESCRIPTION
Libraries that need to be updated are checked with scala steward, so they are no longer needed.