### PR TITLE
fix warning in JsonResult.scala

### DIFF
--- a/json/src/main/scala/org/scalatra/json/JsonResult.scala
+++ b/json/src/main/scala/org/scalatra/json/JsonResult.scala
@@ -5,5 +5,5 @@ import org.json4s.JValue
 case class JsonResult(value: JValue)
 
 object JsonResult {
-  def apply[T](v: T)(implicit T: T => JValue): JsonResult = JsonResult(v: JValue)
+  def apply[T](v: T)(implicit T: T => JValue): JsonResult = JsonResult(T.apply(v))
 }


### PR DESCRIPTION
```
[warn] -- Migration Warning: /home/runner/work/scalatra/scalatra/json/src/main/scala/org/scalatra/json/JsonResult.scala:8:71 
[warn] 8 |  def apply[T](v: T)(implicit T: T => JValue): JsonResult = JsonResult(v: JValue)
[warn]   |                                                                       ^
[warn]   |The conversion (T : T => org.json4s.JValue) will not be applied implicitly here in Scala 3 because only implicit methods and instances of Conversion class will continue to work as implicit views.
```