### PR TITLE
fix warnings

### DIFF
--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -12,6 +12,7 @@ import org.apache.hc.client5.http.classic.methods._
 import org.apache.hc.client5.http.entity.mime.{ ContentBody, StringBody }
 import org.apache.hc.client5.http.entity.mime.{ FormBodyPartBuilder, HttpMultipartMode, MultipartEntityBuilder }
 import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.core5.http.io.HttpClientResponseHandler
 
 import scala.util.DynamicVariable
 
@@ -73,7 +74,8 @@ trait HttpComponentsClient extends Client {
       attachBody(req, body)
       attachHeaders(req, headers)
 
-      withResponse(HttpComponentsClientResponse(client.execute(req))) { f }
+      val handler: HttpClientResponseHandler[A] = res => withResponse(HttpComponentsClientResponse(res))(f)
+      client.execute[A](req, handler)
     }
 
   protected def submitMultipart[A](
@@ -89,7 +91,8 @@ trait HttpComponentsClient extends Client {
       attachMultipartBody(req, params, files)
       attachHeaders(req, headers)
 
-      withResponse(HttpComponentsClientResponse(client.execute(req))) { f }
+      val handler: HttpClientResponseHandler[A] = res => withResponse(HttpComponentsClientResponse(res))(f)
+      client.execute[A](req, handler)
     }
 
   protected def createClient = {


### PR DESCRIPTION
https://github.com/apache/httpcomponents-client/blob/rel/v5.2.1/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/CloseableHttpClient.java#L109-L122

```
[warn] /home/runner/work/scalatra/scalatra/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala:76:56: method execute in class CloseableHttpClient is deprecated
[warn]       withResponse(HttpComponentsClientResponse(client.execute(req))) { f }
[warn]                                                        ^
[warn] /home/runner/work/scalatra/scalatra/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala:92:56: method execute in class CloseableHttpClient is deprecated
[warn]       withResponse(HttpComponentsClientResponse(client.execute(req))) { f }
[warn]                                                        ^
```