### PR TITLE
fix resolveClass bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -399,7 +399,6 @@ lazy val `scalatra-swagger` = projectMatrix.in(file("swagger"))
       parserCombinators,
       logbackClassic % "provided"
     ),
-    scala3migration,
     description := "Scalatra integration with Swagger"
   )
   .jvmPlatform(

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/Reflector.scala
@@ -45,7 +45,6 @@ object Reflector {
 
   def resolveClass[X <: AnyRef](c: String, classLoaders: Iterable[ClassLoader]): Option[Class[X]] = classLoaders match {
     case Nil => sys.error("resolveClass: expected 1+ classloaders but received empty list")
-    case List(cl) => Some(Class.forName(c, true, cl).asInstanceOf[Class[X]])
     case many => {
       try {
         var clazz: Class[?] = null

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/ScalaSigReader.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/ScalaSigReader.scala
@@ -164,7 +164,6 @@ private[reflect] object ScalaSigReader {
 
   def resolveClass[X <: AnyRef](c: String, classLoaders: Iterable[ClassLoader]): Option[Class[X]] = classLoaders match {
     case Nil => sys.error("resolveClass: expected 1+ classloaders but received empty list")
-    case List(cl) => Some(Class.forName(c, true, cl).asInstanceOf[Class[X]])
     case many => {
       try {
         var clazz: Class[?] = null


### PR DESCRIPTION
Don't use `List.unapplySeq` for `Iterable`

```
Welcome to Scala 2.13.14 (OpenJDK 64-Bit Server VM, Java 11.0.23).
Type in expressions for evaluation. Or try :help.

scala> def f[A](a: Iterable[A]): String = a match {
     |   case Nil => "zero"
     |   case List(_) => "one"
     |   case _ => "many"
     | }
def f[A](a: Iterable[A]): String

scala> f(Nil)
val res0: String = zero

scala> f(List(3))
val res1: String = one

scala> f(Vector(3))
val res2: String = many
```