### PR TITLE
fix(api-formats): Gracefully handle invalid Accept header quality

### DIFF
--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -3,9 +3,10 @@ package org.scalatra
 import java.util.Locale.ENGLISH
 import java.util.concurrent.ConcurrentHashMap
 import org.scalatra.ServletCompat.http.{ HttpServletRequest, HttpServletResponse }
-import org.scalatra.util.RicherString.*
+import org.scalatra.util.RicherString._
 
-import scala.jdk.CollectionConverters.*
+
+import scala.jdk.CollectionConverters._
 import scala.collection.concurrent
 import scala.util.Try
 

--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -3,11 +3,11 @@ package org.scalatra
 import java.util.Locale.ENGLISH
 import java.util.concurrent.ConcurrentHashMap
 import org.scalatra.ServletCompat.http.{ HttpServletRequest, HttpServletResponse }
+import org.scalatra.util.RicherString.*
 
-import org.scalatra.util.RicherString._
-
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.concurrent
+import scala.util.Try
 
 object ApiFormats {
 
@@ -113,7 +113,7 @@ trait ApiFormats extends ScalatraBase {
 
   private def parseAcceptHeader(implicit request: HttpServletRequest): List[String] = {
     def isValidQPair(a: Array[String]) = {
-      a.length == 2 && a(0) == "q" && validRange.contains(a(1).toDouble)
+      a.length == 2 && a(0) == "q" && Try(a(1).toDouble).toOption.exists(validRange.contains)
     }
 
     request.headers.get("Accept") map { s =>

--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -3,8 +3,8 @@ package org.scalatra
 import java.util.Locale.ENGLISH
 import java.util.concurrent.ConcurrentHashMap
 import org.scalatra.ServletCompat.http.{ HttpServletRequest, HttpServletResponse }
-import org.scalatra.util.RicherString._
 
+import org.scalatra.util.RicherString._
 
 import scala.jdk.CollectionConverters._
 import scala.collection.concurrent

--- a/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
@@ -84,6 +84,13 @@ class ApiFormatsSpec extends MutableScalatraSpec {
           body must_== "txt"
         }
       }
+
+      "when the priory value is not a double the parser should ignore the broken priority" in {
+        get("/hello", headers = Map("Accept" -> "application/json; q=0.8 oops, text/plain, */*")) {
+          response.getContentType() must startWith("text/plain")
+          body must_== "txt"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Wrap `toDouble` operation in a try to handle cases where invalid string cannot be converted to a double.