### PR TITLE
Removed dependency on StringUtils

### DIFF
--- a/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
+++ b/core/src/main/scala/org/scalatra/servlet/RichRequest.scala
@@ -6,7 +6,6 @@ import java.net.URI
 import java.util.Locale
 
 import org.scalatra.ServletCompat.http.HttpServletRequest
-import org.apache.commons.lang3.StringUtils
 import org.scalatra.util.RicherString._
 import org.scalatra.util.MultiMapHeadView
 
@@ -254,7 +253,7 @@ case class RichRequest(r: HttpServletRequest) extends AttributesMap {
    * This takes the load balancing header X-Forwarded-For into account
    * @return the client ip address
    */
-  def remoteAddress: String = header("X-FORWARDED-FOR").flatMap(_.split(",").map(_.trim).filterNot(StringUtils.isBlank).headOption).getOrElse(r.getRemoteAddr)
+  def remoteAddress: String = header("X-FORWARDED-FOR").flatMap(_.split(",").map(_.trim).filterNot(_.isBlank).headOption).getOrElse(r.getRemoteAddr)
 
   def locale: Locale = r.getLocale
 

--- a/core/src/main/scala/org/scalatra/util/RicherString.scala
+++ b/core/src/main/scala/org/scalatra/util/RicherString.scala
@@ -2,7 +2,6 @@ package org.scalatra.util
 
 import java.nio.charset.{ Charset, StandardCharsets }
 import java.util.regex.Pattern
-import org.apache.commons.lang3.StringUtils
 
 package object RicherString {
 
@@ -10,8 +9,8 @@ package object RicherString {
 
   implicit final class RicherStringImplicitClass(private val orig: String) extends AnyVal {
 
-    def blankOption: Option[String] = if (StringUtils.isBlank(orig)) None else Some(orig)
-    def nonBlank: Boolean = !(StringUtils.isBlank(orig))
+    def blankOption: Option[String] = if (orig == null || orig.isBlank) None else Some(orig)
+    def nonBlank: Boolean = if (orig == null || orig.isBlank) false else true
 
     def urlEncode: String = UrlCodingUtils.urlEncode(orig)
     def formEncode: String = UrlCodingUtils.urlEncode(orig, spaceIsPlus = true)


### PR DESCRIPTION
Since the same method "isBlank" is provided in JDK11.

However, the "isBlank" method in the JDK does not perform null checks, so to maintain the same specification, null checks are performed separately.