### PR TITLE
use new varargs syntax. fix warning with latest Scala 3

### DIFF
--- a/auth/src/main/scala/org/scalatra/auth/Scentry.scala
+++ b/auth/src/main/scala/org/scalatra/auth/Scentry.scala
@@ -110,7 +110,7 @@ class Scentry[UserType <: AnyRef](
   }
 
   def authenticate(names: String*)(implicit request: HttpServletRequest, response: HttpServletResponse): Option[UserType] = {
-    val r = runAuthentication(names: _*) map {
+    val r = runAuthentication(names *) map {
       case (stratName, usr) =>
         runCallbacks() { _.afterAuthenticate(stratName, usr) }
         user_=(usr)

--- a/core/src/main/scala/org/scalatra/ApiFormats.scala
+++ b/core/src/main/scala/org/scalatra/ApiFormats.scala
@@ -102,7 +102,7 @@ trait ApiFormats extends ScalatraBase {
   private[this] def getFromAcceptHeader(implicit request: HttpServletRequest): Option[String] = {
     val hdrs = request.contentType.fold(acceptHeader)(contentType =>
       (acceptHeader ::: List(contentType)).distinct)
-    formatForMimeTypes(hdrs: _*)
+    formatForMimeTypes(hdrs *)
   }
 
   private[this] def getFromResponseHeader(implicit response: HttpServletResponse): Option[String] = {

--- a/core/src/main/scala/org/scalatra/CsrfTokenSupport.scala
+++ b/core/src/main/scala/org/scalatra/CsrfTokenSupport.scala
@@ -101,7 +101,7 @@ trait XsrfTokenSupport { this: ScalatraBase =>
     request.getSession.getAttribute(xsrfKey).asInstanceOf[String]
 
   def xsrfGuard(only: RouteTransformer*): Unit = {
-    before((only.toSeq ++ Seq[RouteTransformer](isForged)): _*) { handleForgery() }
+    before(((only.toSeq ++ Seq[RouteTransformer](isForged))) *) { handleForgery() }
   }
 
   before() { prepareXsrfToken() }

--- a/core/src/main/scala/org/scalatra/HttpMethod.scala
+++ b/core/src/main/scala/org/scalatra/HttpMethod.scala
@@ -52,9 +52,9 @@ case class ExtensionMethod(name: String) extends HttpMethod {
 
 object HttpMethod {
   private[this] val methodMap =
-    Map(List(Options, Get, Head, Post, Put, Delete, Trace, Connect, Patch) map {
+    Map((List(Options, Get, Head, Post, Put, Delete, Trace, Connect, Patch) map {
       method => (method.toString, method)
-    }: _*)
+    }) *)
 
   /**
    * Maps a String as an HttpMethod.

--- a/core/src/main/scala/org/scalatra/servlet/AsyncSupport.scala
+++ b/core/src/main/scala/org/scalatra/servlet/AsyncSupport.scala
@@ -68,42 +68,42 @@ trait AsyncSupport extends ServletBase with ScalatraAsyncSupport {
    *
    */
   def asyncGet(transformers: RouteTransformer*)(block: => Any): Route = {
-    get(transformers: _*)(asynchronously(block)())
+    get(transformers *)(asynchronously(block)())
   }
 
   /**
    * @see asyncGet
    */
   def asyncPost(transformers: RouteTransformer*)(block: => Any): Route = {
-    post(transformers: _*)(asynchronously(block)())
+    post(transformers *)(asynchronously(block)())
   }
 
   /**
    * @see asyncGet
    */
   def asyncPut(transformers: RouteTransformer*)(block: => Any): Route = {
-    put(transformers: _*)(asynchronously(block)())
+    put(transformers *)(asynchronously(block)())
   }
 
   /**
    * @see asyncGet
    */
   def asyncDelete(transformers: RouteTransformer*)(block: => Any): Route = {
-    delete(transformers: _*)(asynchronously(block)())
+    delete(transformers *)(asynchronously(block)())
   }
 
   /**
    * @see asyncGet
    */
   def asyncOptions(transformers: RouteTransformer*)(block: => Any): Route = {
-    options(transformers: _*)(asynchronously(block)())
+    options(transformers *)(asynchronously(block)())
   }
 
   /**
    * @see asyncGet
    */
   def asyncPatch(transformers: RouteTransformer*)(block: => Any): Route = {
-    patch(transformers: _*)(asynchronously(block)())
+    patch(transformers *)(asynchronously(block)())
   }
 
 }

--- a/core/src/main/scala/org/scalatra/util/Inflector.scala
+++ b/core/src/main/scala/org/scalatra/util/Inflector.scala
@@ -123,7 +123,7 @@ object Inflector extends Inflector {
     def ordinalize = Inflector.ordinalize(word)
     def pluralize = Inflector.pluralize(word)
     def singularize = Inflector.singularize(word)
-    def fill(values: (String, String)*) = Inflector.interpolate(word, Map(values: _*))
+    def fill(values: (String, String)*) = Inflector.interpolate(word, Map(values *))
   }
 
   class InflectorInt(private val number: Int) extends AnyVal {

--- a/core/src/main/scala/org/scalatra/util/MapQueryString.scala
+++ b/core/src/main/scala/org/scalatra/util/MapQueryString.scala
@@ -46,9 +46,9 @@ case class MapQueryString(initialValues: Seq[(String, Seq[String])], rawValue: S
 
   val empty = Map.empty[String, List[String]]
 
-  def value: Value = Map(initialValues: _*)
+  def value: Value = Map(initialValues *)
 
-  def normalize: MapQueryString = copy(SortedMap(initialValues filter (k => !MapQueryString.DEFAULT_EXCLUSIONS.contains(k._1)): _*).toSeq)
+  def normalize: MapQueryString = copy(SortedMap((initialValues filter (k => !MapQueryString.DEFAULT_EXCLUSIONS.contains(k._1))) *).toSeq)
 
   private def mkString(values: Value = value) = values map {
     case (k, v) => v.map(s => "%s=%s".format(UrlCodingUtils.queryPartEncode(k), UrlCodingUtils.queryPartEncode(s))).mkString("&")

--- a/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
+++ b/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
@@ -10,8 +10,8 @@ import scala.util.matching.Regex.Match
 
 trait UrlCodingUtils {
 
-  private val toSkip = BitSet((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "!$&'()*+,;=:/?@-._~".toSet).map(_.toInt): _*)
-  private val toSkipEncoding = BitSet((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ ":@-._~".toSet).map(_.toInt): _*)
+  private val toSkip = BitSet((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "!$&'()*+,;=:/?@-._~".toSet).map(_.toInt) *)
+  private val toSkipEncoding = BitSet((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ ":@-._~".toSet).map(_.toInt) *)
   private val toSkipQueryEncoding = toSkipEncoding ++ BitSet('/', '?')
   private val space = ' '.toInt
   private val PctEncoded = """%([0-9a-fA-F][0-9a-fA-F])""".r

--- a/forms/src/main/scala/org/scalatra/forms/ValueType.scala
+++ b/forms/src/main/scala/org/scalatra/forms/ValueType.scala
@@ -30,7 +30,7 @@ abstract class SingleValueType[T](constraints: Constraint*) extends ValueType[T]
     validate(name, getSingleParam(params, name).orNull, params, messages)
 
   def validate(name: String, value: String, params: Map[String, Seq[String]], messages: Messages): Seq[(String, String)] =
-    validaterec(name, value, params, Seq(constraints: _*), messages)
+    validaterec(name, value, params, Seq(constraints *), messages)
 
   @scala.annotation.tailrec
   private def validaterec(name: String, value: String, params: Map[String, Seq[String]],

--- a/forms/src/main/scala/org/scalatra/forms/package.scala
+++ b/forms/src/main/scala/org/scalatra/forms/package.scala
@@ -15,14 +15,14 @@ package object forms {
   /**
    * ValueType for the String property.
    */
-  def text(constraints: Constraint*): SingleValueType[String] = new SingleValueType[String](constraints: _*) {
+  def text(constraints: Constraint*): SingleValueType[String] = new SingleValueType[String](constraints *) {
     def convert(value: String, messages: Messages): String = value
   }
 
   /**
    * ValueType for the Boolean property.
    */
-  def boolean(constraints: Constraint*): SingleValueType[Boolean] = new SingleValueType[Boolean](constraints: _*) {
+  def boolean(constraints: Constraint*): SingleValueType[Boolean] = new SingleValueType[Boolean](constraints *) {
     def convert(value: String, messages: Messages): Boolean = value match {
       case null | "" | "false" | "FALSE" => false
       case _ => true
@@ -32,7 +32,7 @@ package object forms {
   /**
    * ValueType for the Int property.
    */
-  def number(constraints: Constraint*): SingleValueType[Int] = new SingleValueType[Int](constraints: _*) {
+  def number(constraints: Constraint*): SingleValueType[Int] = new SingleValueType[Int](constraints *) {
 
     def convert(value: String, messages: Messages): Int = value match {
       case null | "" => 0
@@ -55,7 +55,7 @@ package object forms {
   /**
    * ValueType for the Double property.
    */
-  def double(constraints: Constraint*): SingleValueType[Double] = new SingleValueType[Double](constraints: _*) {
+  def double(constraints: Constraint*): SingleValueType[Double] = new SingleValueType[Double](constraints *) {
 
     def convert(value: String, messages: Messages): Double = value match {
       case null | "" => 0d
@@ -78,7 +78,7 @@ package object forms {
   /**
    * ValueType for the Long property.
    */
-  def long(constraints: Constraint*): SingleValueType[Long] = new SingleValueType[Long](constraints: _*) {
+  def long(constraints: Constraint*): SingleValueType[Long] = new SingleValueType[Long](constraints *) {
 
     def convert(value: String, messages: Messages): Long = value match {
       case null | "" => 0L
@@ -102,7 +102,7 @@ package object forms {
    * ValueType for the java.util.Date property.
    */
   def date(pattern: String, constraints: Constraint*): SingleValueType[java.util.Date] =
-    new SingleValueType[java.util.Date]((datePattern(pattern) +: constraints): _*) {
+    new SingleValueType[java.util.Date](((datePattern(pattern) +: constraints)) *) {
       def convert(value: String, messages: Messages): java.util.Date = value match {
         case null | "" => null
         case value => new java.text.SimpleDateFormat(pattern).parse(value)

--- a/forms/src/main/scala/org/scalatra/forms/views.scala
+++ b/forms/src/main/scala/org/scalatra/forms/views.scala
@@ -13,21 +13,21 @@ object views {
    * Render a text field.
    */
   def text(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): String = {
-    s"""<input type="text" name="${escape(name)}" value="${escape(param(name))}" ${attrs(attributes: _*)}>"""
+    s"""<input type="text" name="${escape(name)}" value="${escape(param(name))}" ${attrs(attributes *)}>"""
   }
 
   /**
    * Render a password field.
    */
   def password(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): String = {
-    s"""<input type="password" name="${escape(name)}" ${attrs(attributes: _*)}>"""
+    s"""<input type="password" name="${escape(name)}" ${attrs(attributes *)}>"""
   }
 
   /**
    * Render a textarea.
    */
   def textarea(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): String = {
-    s"""<textarea name="${escape(name)}" ${attrs(attributes: _*)}>${escape(param(name))}</textarea>"""
+    s"""<textarea name="${escape(name)}" ${attrs(attributes *)}>${escape(param(name))}</textarea>"""
   }
 
   /**
@@ -35,7 +35,7 @@ object views {
    */
   def checkbox(name: String, value: String, attributes: (String, String)*)(implicit request: HttpServletRequest): String = {
     val checked = if (params(name).contains(value)) "checked" else ""
-    s"""<input type="checkbox" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>"""
+    s"""<input type="checkbox" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes *)}>"""
   }
 
   /**
@@ -43,7 +43,7 @@ object views {
    */
   def radio(name: String, value: String, attributes: (String, String)*)(implicit request: HttpServletRequest): String = {
     val checked = if (param(name) == value) "checked" else ""
-    s"""<input type="radio" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>"""
+    s"""<input type="radio" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes *)}>"""
   }
 
   /**

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerBase.scala
@@ -171,7 +171,7 @@ trait SwaggerBase extends Initializable { self: ScalatraBase with JsonSupport[?]
                             generateAllowableValues(property.allowableValues, property.minimumValue, property.maximumValue) ~
                             ("default" -> toTypedAst(property.default, property.`type`)) ~~
                             generateDataType(property.`type`))
-                      }: _*)) ~!
+                      } *)) ~!
                       ("required" -> model.getVisibleProperties.collect {
                         case (name, property) if property.required => name
                       }))

--- a/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/SwaggerSupport.scala
@@ -160,7 +160,7 @@ object SwaggerSupportSyntax {
     def fromForm: this.type = paramType(ParamType.Form)
 
     def allowableValues[V](values: V*): this.type = {
-      _allowableValues = if (values.isEmpty) AllowableValues.empty else AllowableValues(values: _*)
+      _allowableValues = if (values.isEmpty) AllowableValues.empty else AllowableValues(values *)
       this
     }
     def allowableValues[V](values: List[V]): this.type = {

--- a/swagger/src/main/scala/org/scalatra/swagger/reflect/ManifestFactory.scala
+++ b/swagger/src/main/scala/org/scalatra/swagger/reflect/ManifestFactory.scala
@@ -14,7 +14,7 @@ private[swagger] object ManifestFactory {
       if (pt.getOwnerType == null) {
         manifestOf(clazz, typeArgs.toIndexedSeq)
       } else {
-        Manifest.classType(manifestOf(pt.getOwnerType), clazz, typeArgs.toIndexedSeq: _*)
+        Manifest.classType(manifestOf(pt.getOwnerType), clazz, typeArgs.toIndexedSeq *)
       }
 
     case at: GenericArrayType =>
@@ -46,7 +46,7 @@ private[swagger] object ManifestFactory {
         else
           erasure
 
-      Manifest.classType(normalizedErasure, typeArgs.head, typeArgs.tail: _*)
+      Manifest.classType(normalizedErasure, typeArgs.head, typeArgs.tail *)
     }
   }
 

--- a/twirl/src/main/scala/org/scalatra/twirl/ScalatraFormsHelpers.scala
+++ b/twirl/src/main/scala/org/scalatra/twirl/ScalatraFormsHelpers.scala
@@ -14,21 +14,21 @@ trait ScalatraFormsHelpers {
    * Render a text field.
    */
   def text(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): Html = {
-    Html(s"""<input type="text" name="${escape(name)}" value="${escape(param(name))}" ${attrs(attributes: _*)}>""")
+    Html(s"""<input type="text" name="${escape(name)}" value="${escape(param(name))}" ${attrs(attributes *)}>""")
   }
 
   /**
    * Render a password field.
    */
   def password(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): Html = {
-    Html(s"""<input type="password" name="${escape(name)}" ${attrs(attributes: _*)}>""")
+    Html(s"""<input type="password" name="${escape(name)}" ${attrs(attributes *)}>""")
   }
 
   /**
    * Render a textarea.
    */
   def textarea(name: String, attributes: (String, String)*)(implicit request: HttpServletRequest): Html = {
-    Html(s"""<textarea name="${escape(name)}" ${attrs(attributes: _*)}>${escape(param(name))}</textarea>""")
+    Html(s"""<textarea name="${escape(name)}" ${attrs(attributes *)}>${escape(param(name))}</textarea>""")
   }
 
   /**
@@ -36,7 +36,7 @@ trait ScalatraFormsHelpers {
    */
   def checkbox(name: String, value: String, attributes: (String, String)*)(implicit request: HttpServletRequest): Html = {
     val checked = if (params(name).contains(value)) "checked" else ""
-    Html(s"""<input type="checkbox" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>""")
+    Html(s"""<input type="checkbox" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes *)}>""")
   }
 
   /**
@@ -44,7 +44,7 @@ trait ScalatraFormsHelpers {
    */
   def radio(name: String, value: String, attributes: (String, String)*)(implicit request: HttpServletRequest): Html = {
     val checked = if (param(name) == value) "checked" else ""
-    Html(s"""<input type="radio" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes: _*)}>""")
+    Html(s"""<input type="radio" name="${escape(name)}" value="${escape(value)}" $checked ${attrs(attributes *)}>""")
   }
 
   /**


### PR DESCRIPTION
```
Welcome to Scala 3.5.1-RC2 (21.0.4, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> List(Seq(1, 2) : _*)
1 warning found
-- Warning: --------------------------------------------------------------------
1 |List(Seq(1, 2) : _*)
  |                 ^
  |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
val res0: List[Int] = List(1, 2)
                                                                                                                                             
scala> List(Seq(1, 2) *)
val res1: List[Int] = List(1, 2)
```