### PR TITLE
1786: ensuring resources with file protocols are resolved properly

### DIFF
--- a/jetty/src/test/scala/org/scalatra/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/scalatra/jetty/JettyServerSpec.scala
@@ -32,9 +32,11 @@ class JettyServerSpec extends AnyWordSpec with BeforeAndAfterAll {
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     val urls = getClass.getClassLoader.getResources("").asScala.toSeq
-    val fileUrl = urls.find(_.getProtocol == "file").getOrElse(
-      throw new IllegalStateException("No file URL found in class loader resources")
-    )
+    val fileUrl = urls
+      .find(_.getProtocol == "file")
+      .getOrElse(
+        throw new IllegalStateException("No file URL found in class loader resources")
+      )
     jetty = new JettyServer(
       InetSocketAddress.createUnresolved("localhost", 0),
       Path.of(fileUrl.toURI)

--- a/jetty/src/test/scala/org/scalatra/jetty/JettyServerSpec.scala
+++ b/jetty/src/test/scala/org/scalatra/jetty/JettyServerSpec.scala
@@ -11,6 +11,7 @@ import scala.io.Source
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
 
 object JettyServerSpec {
   class HelloServlet extends ScalatraServlet {
@@ -30,9 +31,13 @@ class JettyServerSpec extends AnyWordSpec with BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
+    val urls = getClass.getClassLoader.getResources("").asScala.toSeq
+    val fileUrl = urls.find(_.getProtocol == "file").getOrElse(
+      throw new IllegalStateException("No file URL found in class loader resources")
+    )
     jetty = new JettyServer(
       InetSocketAddress.createUnresolved("localhost", 0),
-      Path.of(getClass.getClassLoader.getResource("").toURI)
+      Path.of(fileUrl.toURI)
     )
     jetty.context.setInitParameter(ScalatraListener.LifeCycleKey, classOf[JettyServerSpec.ScalatraBootstrap].getName)
     jetty.start()

--- a/test/src/main/scala/org/scalatra/test/Container.scala
+++ b/test/src/main/scala/org/scalatra/test/Container.scala
@@ -1,13 +1,18 @@
 package org.scalatra.test
 
 import java.nio.file.{Path, Paths}
+import scala.jdk.CollectionConverters.*
 
 trait Container {
   protected def ensureSessionIsSerializable(): Unit
   protected def start(): Unit
   protected def stop(): Unit
   var resourceBasePath: Path = {
-    val projectPath = Paths.get(getClass.getClassLoader.getResource("").toURI.resolve("../../.."))
+    val urls = getClass.getClassLoader.getResources("").asScala.toSeq
+    val fileUrl = urls.find(_.getProtocol == "file").getOrElse(
+      throw new IllegalStateException("No file URL found in class loader resources")
+    )
+    val projectPath = Paths.get(fileUrl.toURI).resolve("../../..")
     val webAppPath  = projectPath.resolve("src/main/webapp")
     if (webAppPath.toFile.isDirectory) {
       webAppPath

--- a/test/src/main/scala/org/scalatra/test/Container.scala
+++ b/test/src/main/scala/org/scalatra/test/Container.scala
@@ -9,9 +9,11 @@ trait Container {
   protected def stop(): Unit
   var resourceBasePath: Path = {
     val urls = getClass.getClassLoader.getResources("").asScala.toSeq
-    val fileUrl = urls.find(_.getProtocol == "file").getOrElse(
-      throw new IllegalStateException("No file URL found in class loader resources")
-    )
+    val fileUrl = urls
+      .find(_.getProtocol == "file")
+      .getOrElse(
+        throw new IllegalStateException("No file URL found in class loader resources")
+      )
     val projectPath = Paths.get(fileUrl.toURI).resolve("../../..")
     val webAppPath  = projectPath.resolve("src/main/webapp")
     if (webAppPath.toFile.isDirectory) {


### PR DESCRIPTION
Fixes https://github.com/scalatra/scalatra/issues/1786

In certain systems (In this case, bouncycastle FIPS provider setup) JAR files get higher priority when you do something like `https://github.com/scalatra/scalatra/issues/1786`. 