### PR TITLE
fix: order of operation & default contentType behaviour in HttpComponentsClient submit

### DIFF
--- a/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
@@ -97,13 +97,13 @@ class ApiFormatsSpec extends MutableScalatraSpec {
       }
 
       "should use default format when Content-Type is undefined" in {
-        submit("POST", "/mime", body="[]") {
+        submit("POST", "/mime", body = "[]") {
           response.getHeader("Request-Mime") must equalTo("application/json")
         }
       }
 
       "should use Content-Type when it's defined" in {
-        submit("POST", "/mime", body="[]", headers=Seq(("Content-Type", "text/html"))) {
+        submit("POST", "/mime", body = "[]", headers = Seq(("Content-Type", "text/html"))) {
           response.getHeader("Request-Mime") must equalTo("html")
         }
       }

--- a/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
@@ -13,6 +13,10 @@ class ApiFormatsServlet extends ScalatraServlet with ApiFormats {
     format
   }
 
+  post("/mime") {
+    format = formats("json")
+    response.setHeader("Request-Mime", requestFormat)
+  }
 }
 
 class ApiFormatsSpec extends MutableScalatraSpec {
@@ -89,6 +93,18 @@ class ApiFormatsSpec extends MutableScalatraSpec {
         get("/hello", headers = Map("Accept" -> "application/json; q=0.8 oops, text/plain, */*")) {
           response.getContentType() must startWith("text/plain")
           body must_== "txt"
+        }
+      }
+
+      "should use default format when Content-Type is undefined" in {
+        submit("POST", "/mime", body="[]") {
+          response.getHeader("Request-Mime") must equalTo("application/json")
+        }
+      }
+
+      "should use Content-Type is when defined" in {
+        submit("POST", "/mime", body="[]", headers=Seq(("Content-Type", "text/html"))) {
+          response.getHeader("Request-Mime") must equalTo("html")
         }
       }
     }

--- a/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
+++ b/core/src/test/scala/org/scalatra/ApiFormatsSpec.scala
@@ -102,7 +102,7 @@ class ApiFormatsSpec extends MutableScalatraSpec {
         }
       }
 
-      "should use Content-Type is when defined" in {
+      "should use Content-Type when it's defined" in {
         submit("POST", "/mime", body="[]", headers=Seq(("Content-Type", "text/html"))) {
           response.getHeader("Request-Mime") must equalTo("html")
         }

--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -72,8 +72,8 @@ trait HttpComponentsClient extends Client {
         s"${buildUrl(baseUrl, path)}?$queryString"
 
     val req = createMethod(method.toUpperCase, url)
-    attachBody(req, body)
     attachHeaders(req, headers)
+    attachBody(req, body)
 
     val handler: HttpClientResponseHandler[A] = res => withResponse(HttpComponentsClientResponse(res))(f)
     client.execute[A](req, handler)

--- a/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
+++ b/test/src/main/scala/org/scalatra/test/HttpComponentsClient.scala
@@ -140,7 +140,7 @@ trait HttpComponentsClient extends Client {
           if (req.containsHeader("Content-Type"))
             ContentType.parse(req.getHeader("Content-Type").getValue)
           else
-            ContentType.TEXT_PLAIN
+            null
 
         req.setEntity(new ByteArrayEntity(body, contentType))
       }


### PR DESCRIPTION
Proposed fix to https://github.com/scalatra/scalatra/issues/1814

Content type should be left as null:
https://hc.apache.org/httpcomponents-core-5.3.x/current/httpcore5/apidocs/org/apache/hc/core5/http/io/entity/ByteArrayEntity.html#ByteArrayEntity-byte:A-org.apache.hc.core5.http.ContentType-

>  Parameters:
    buf - The message body contents as a byte array buffer.
    contentType - The content-type, may be null.
