### PR TITLE
Migrate from Jakarta EE 10 to 11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,17 @@ lazy val scalatraSettings = Seq(
   mimaPreviousArtifacts ++= Set("3.1.2").map(
     organization.value %% moduleName.value % _
   ),
+  mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "org.scalatra.test.EmbeddedJettyContainer.servletContextHandler"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalatra.test.JettyContainer.addServlet"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalatra.test.JettyContainer.addFilter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalatra.test.JettyContainer.mount"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalatra.jetty.JettyServer.context"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalatra.test.JettyContainer.servletContextHandler"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.scalatra.test.JettyContainer.servletContextHandler")
+  ),
   Test / fork          := true,
   Test / baseDirectory := (ThisBuild / baseDirectory).value,
   Test / testOptions ++= {

--- a/compat/src/main/scala-jakarta-jvm/org/scalatra/JettyCompat.scala
+++ b/compat/src/main/scala-jakarta-jvm/org/scalatra/JettyCompat.scala
@@ -5,14 +5,14 @@ import org.eclipse.jetty.util.resource.ResourceFactory
 import java.nio.file.Path
 
 private[scalatra] object JettyCompat {
-  type DefaultServlet        = org.eclipse.jetty.ee10.servlet.DefaultServlet
-  type FilterHolder          = org.eclipse.jetty.ee10.servlet.FilterHolder
-  type ServletContextHandler = org.eclipse.jetty.ee10.servlet.ServletContextHandler
-  type ServletHolder         = org.eclipse.jetty.ee10.servlet.ServletHolder
+  type DefaultServlet        = org.eclipse.jetty.ee11.servlet.DefaultServlet
+  type FilterHolder          = org.eclipse.jetty.ee11.servlet.FilterHolder
+  type ServletContextHandler = org.eclipse.jetty.ee11.servlet.ServletContextHandler
+  type ServletHolder         = org.eclipse.jetty.ee11.servlet.ServletHolder
 
   def createServletContextHandler(resourceBasePath: Path): ServletContextHandler = {
-    val servletContextHandler = new org.eclipse.jetty.ee10.servlet.ServletContextHandler(
-      org.eclipse.jetty.ee10.servlet.ServletContextHandler.SESSIONS
+    val servletContextHandler = new org.eclipse.jetty.ee11.servlet.ServletContextHandler(
+      org.eclipse.jetty.ee11.servlet.ServletContextHandler.SESSIONS
     )
     servletContextHandler.setBaseResource(ResourceFactory.of(servletContextHandler).newResource(resourceBasePath))
     servletContextHandler

--- a/compat/src/main/scala-jakarta-jvm/org/scalatra/ServletCompat.scala
+++ b/compat/src/main/scala-jakarta-jvm/org/scalatra/ServletCompat.scala
@@ -8,6 +8,7 @@ private[scalatra] object ServletCompat {
   type Filter                 = jakarta.servlet.Filter
   type FilterChain            = jakarta.servlet.FilterChain
   type FilterConfig           = jakarta.servlet.FilterConfig
+  type HttpServlet            = jakarta.servlet.http.HttpServlet
   type MultipartConfigElement = jakarta.servlet.MultipartConfigElement
   type ReadListener           = jakarta.servlet.ReadListener
   type Servlet                = jakarta.servlet.Servlet

--- a/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
+++ b/core/src/main/scala/org/scalatra/servlet/FileUploadSupport.scala
@@ -69,7 +69,7 @@ trait FileUploadSupport extends ServletBase with HasMultipartConfig {
   protected def isSizeConstraintException(e: Exception): Boolean = e match {
     // Jetty 10: see "org.eclipse.jetty.server.MultiPartFormInputStream.MultiPart::write".
     case exc: IllegalStateException => exc.getMessage.matches("^Multipart Mime part .+ exceeds max filesize$")
-    // Jetty 12: see "org.eclipse.jetty.ee10.servlet.ServletApiRequest::getParts".
+    // Jetty 12: see "org.eclipse.jetty.ee11.servlet.ServletApiRequest::getParts".
     case exc: ServletException =>
       val rootCause = exc.getRootCause
       rootCause.getMessage == "400: bad multipart" && (rootCause.getCause match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ object Dependencies {
   lazy val httpclient          = "org.apache.httpcomponents.client5" % "httpclient5"              % "5.6"
   lazy val jettyServletJavax   = "org.eclipse.jetty"                 % "jetty-servlet"            % "10.0.21"
   lazy val jettyWebappJavax    = "org.eclipse.jetty"                 % "jetty-webapp"             % "10.0.26"
-  lazy val jettyServletJakarta = "org.eclipse.jetty.ee10"            % "jetty-ee10-servlet"       % "12.1.5"
-  lazy val jettyWebappJakarta  = "org.eclipse.jetty.ee10"            % "jetty-ee10-webapp"        % "12.1.5"
+  lazy val jettyServletJakarta = "org.eclipse.jetty.ee11"            % "jetty-ee11-servlet"       % "12.1.5"
+  lazy val jettyWebappJakarta  = "org.eclipse.jetty.ee11"            % "jetty-ee11-webapp"        % "12.1.5"
   lazy val json4sCore          = "org.json4s"                       %% "json4s-core"              % json4sVersion
   lazy val json4sJackson       = "org.json4s"                       %% "json4s-jackson"           % json4sVersion
   lazy val json4sNative        = "org.json4s"                       %% "json4s-native"            % json4sVersion

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.1.3-SNAPSHOT"
+ThisBuild / version := "3.2.0-SNAPSHOT"


### PR DESCRIPTION
Jakarta EE 11 has been released 6 months ago and has started being integrated in projects like Spring Framework 7 / Spring Boot 4.
This MR is about moving from EE 10 to 11, without any other functional changes.
Due to this jump of the EE dependency, this MR also bumps the version of Scalatra.