### PR TITLE
fix: Container prevented use Scalatra test utils in Jmh & #1960 incorrect impl

### DIFF
--- a/core/src/main/scala/org/scalatra/PathPatternParsers.scala
+++ b/core/src/main/scala/org/scalatra/PathPatternParsers.scala
@@ -92,9 +92,8 @@ class SinatraPathPatternParser extends RegexPathPatternParser {
 
 object SinatraPathPatternParser {
 
-  private val parser                      = new SinatraPathPatternParser()
-  def apply(pattern: String): PathPattern = parser.apply(pattern)
-
+  def apply(pattern: String): PathPattern =
+    new SinatraPathPatternParser().apply(pattern)
 }
 
 /** Path pattern parser based on Rack::Mount::Strexp, which is used by Rails.
@@ -141,7 +140,6 @@ class RailsPathPatternParser extends RegexPathPatternParser {
 
 object RailsPathPatternParser {
 
-  private final val parser                = new RailsPathPatternParser()
-  def apply(pattern: String): PathPattern = parser.apply(pattern)
-
+  def apply(pattern: String): PathPattern =
+    new RailsPathPatternParser().apply(pattern)
 }

--- a/core/src/main/scala/org/scalatra/RouteMatcher.scala
+++ b/core/src/main/scala/org/scalatra/RouteMatcher.scala
@@ -36,10 +36,11 @@ trait ReversibleRouteMatcher {
 /** An implementation of Sinatra's path pattern syntax.
   */
 final class SinatraRouteMatcher(pattern: String) extends RouteMatcher with ReversibleRouteMatcher {
+  private val parser = SinatraPathPatternParser(pattern)
 
   lazy val generator: (Builder => Builder) = BuilderGeneratorParser(pattern)
 
-  def apply(requestPath: String): Option[MultiParams] = SinatraPathPatternParser(pattern)(requestPath)
+  def apply(requestPath: String): Option[MultiParams] = parser(requestPath)
 
   def reverse(params: Map[String, String], splats: List[String]): String =
     generator(Builder("", params, splats)).get
@@ -106,10 +107,11 @@ final class SinatraRouteMatcher(pattern: String) extends RouteMatcher with Rever
 /** An implementation of Rails' path pattern syntax
   */
 final class RailsRouteMatcher(pattern: String) extends RouteMatcher with ReversibleRouteMatcher {
+  private val parser = RailsPathPatternParser(pattern)
 
   lazy val generator: (Builder => Builder) = BuilderGeneratorParser(pattern)
 
-  def apply(requestPath: String): Option[MultiParams] = RailsPathPatternParser(pattern)(requestPath)
+  def apply(requestPath: String): Option[MultiParams] = parser(requestPath)
 
   def reverse(params: Map[String, String], splats: List[String]): String =
     generator(Builder("", params)).get

--- a/test/src/main/scala/org/scalatra/test/Container.scala
+++ b/test/src/main/scala/org/scalatra/test/Container.scala
@@ -9,17 +9,16 @@ trait Container {
   protected def stop(): Unit
   var resourceBasePath: Path = {
     val urls    = getClass.getClassLoader.getResources("").asScala.toSeq
-    val fileUrl = urls
-      .find(_.getProtocol == "file")
-      .getOrElse(
-        throw new IllegalStateException("No file URL found in class loader resources")
-      )
-    val projectPath = Paths.get(fileUrl.toURI).resolve("../../..")
-    val webAppPath  = projectPath.resolve("src/main/webapp")
-    if (webAppPath.toFile.isDirectory) {
-      webAppPath
-    } else {
-      projectPath
+    val fileUrl = urls.find(_.getProtocol == "file")
+
+    fileUrl match {
+      case Some(url) =>
+        val projectPath = Paths.get(url.toURI).resolve("../../..")
+        val webAppPath  = projectPath.resolve("src/main/webapp")
+        if (webAppPath.toFile.isDirectory) webAppPath else projectPath
+      case None =>
+        // Fallback for JMH/JAR contexts where file URLs aren't available
+        Paths.get(System.getProperty("user.dir"))
     }
   }
 }


### PR DESCRIPTION
Fix to the #1960 implementation being slightly incorrect, no performance gains until https://github.com/scalatra/scalatra/pull/1961/changes/76e82247814500c28313eb5ef7c78367e094b3ad

The solution to throw when no value was not found, would result in threaded tests & Jmh to exit early. This default fallback helped with my testing, and now it is also possible write over the variable if path is not found automatically.

Relates to the older issue #1786 this change should be compatible with it, but allowing for slightly different use-cases if needed.