### PR TITLE
Small optimization of invalid uri chars check

### DIFF
--- a/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
+++ b/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
@@ -8,6 +8,16 @@ import scala.collection.immutable.BitSet
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
+object UrlCodingTable {
+  private val table = Array.tabulate[Boolean](256)(c =>
+    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+      ".-_~:/?#[]@!$&'()*+,;=".contains(c.toChar)
+  )
+
+  @inline def containsInvalidUriCharsTable(string: String): Boolean =
+    string.exists(c => c >= 256 || !table(c.toInt))
+}
+
 trait UrlCodingUtils {
 
   private val toSkip = BitSet(
@@ -18,7 +28,6 @@ trait UrlCodingUtils {
   private val space               = ' '.toInt
   private val PctEncoded          = """%([0-9a-fA-F][0-9a-fA-F])""".r
   private val LowerPctEncoded     = """%([0-9a-f][0-9a-f])""".r
-  private val InvalidChars        = "[^\\.a-zA-Z0-9!$&'()*+,;=:/?#\\[\\]@-_~]".r
 
   private val HexUpperCaseChars = (0 until 16) map { i => Character.toUpperCase(Character.forDigit(i, 16)) }
 
@@ -26,9 +35,7 @@ trait UrlCodingUtils {
     PctEncoded.findFirstIn(string).isDefined
   }
 
-  def containsInvalidUriChars(string: String): Boolean = {
-    InvalidChars.findFirstIn(string).isDefined
-  }
+  def containsInvalidUriChars(string: String): Boolean = UrlCodingTable.containsInvalidUriCharsTable(string)
 
   def needsUrlEncoding(string: String): Boolean = {
     !isUrlEncoded(string) && containsInvalidUriChars(string)

--- a/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
+++ b/core/src/main/scala/org/scalatra/util/UrlCodingUtils.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.BitSet
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
-object UrlCodingTable {
+private[util] object UrlCodingTable {
   private val table = Array.tabulate[Boolean](256)(c =>
     (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
       ".-_~:/?#[]@!$&'()*+,;=".contains(c.toChar)

--- a/core/src/test/scala/org/scalatra/UriDecoderTest.scala
+++ b/core/src/test/scala/org/scalatra/UriDecoderTest.scala
@@ -1,0 +1,180 @@
+package org.scalatra
+
+import org.scalatra.test.scalatest.ScalatraFunSuite
+
+class UriDecoderTest extends ScalatraFunSuite {
+
+  test("Non-encoded values can be decoded") {
+    val expected = "https://example.com/foo/bar?test=80&test ab~~"
+    UriDecoder.decode(expected) should equal(expected)
+  }
+
+  test("Encoded values can be decoded") {
+    val expected = "https://example.com/foo/bar?test=80&foo=test ab"
+    UriDecoder.decode("https%3A%2F%2Fexample.com%2Ffoo%2Fbar%3Ftest%3D80%26foo%3Dtest%20ab") should equal(expected)
+  }
+
+  test("Already decoded values remain unchanged") {
+    val uri = "https://example.com/path/to/resource"
+    UriDecoder.decode(uri) should equal(uri)
+  }
+
+  test("Partially encoded URIs are decoded") {
+    val expected = "https://example.com/foo bar/baz"
+    UriDecoder.decode("https://example.com/foo%20bar/baz") should equal(expected)
+  }
+
+  test("Special characters are decoded correctly") {
+    UriDecoder.decode("test%21%40%23%24%25") should equal("test!@#$%")
+  }
+
+  test("Plus signs are NOT treated as spaces (plusIsSpace = false)") {
+    UriDecoder.decode("test+value") should equal("test+value")
+    UriDecoder.decode("test%2Bvalue") should equal("test+value")
+  }
+
+  test("Unicode characters are decoded correctly") {
+    val expected = "https://example.com/こんにちは"
+    UriDecoder.decode("https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF") should equal(expected)
+  }
+
+  test("Emoji are decoded correctly") {
+    val expected = "test 😀 emoji"
+    UriDecoder.decode("test%20%F0%9F%98%80%20emoji") should equal(expected)
+  }
+
+  test("Mixed encoded and non-encoded characters") {
+    val expected = "https://example.com/path?query=value with spaces&other=test"
+    UriDecoder.decode("https://example.com/path?query=value%20with%20spaces&other=test") should equal(expected)
+  }
+
+  test("Reserved characters in URI components") {
+    val expected = "https://example.com/path?key=value&another=test"
+    UriDecoder.decode("https://example.com/path?key=value&another=test") should equal(expected)
+  }
+
+  test("Handles malformed percent encoding gracefully") {
+    // Single % at end
+    UriDecoder.decode("test%") should equal("test%")
+
+    // Invalid hex characters
+    UriDecoder.decode("test%ZZ") should equal("test%ZZ")
+
+    // Incomplete encoding
+    UriDecoder.decode("test%2") should equal("test%2")
+  }
+
+  test("Empty string") {
+    UriDecoder.decode("") should equal("")
+  }
+
+  test("Only percent sign") {
+    UriDecoder.decode("%") should equal("%")
+  }
+
+  test("Multiple consecutive spaces encoded") {
+    val expected = "test    multiple"
+    UriDecoder.decode("test%20%20%20%20multiple") should equal(expected)
+  }
+
+  test("Fragment identifiers are preserved") {
+    val expected = "https://example.com/path#section"
+    UriDecoder.decode("https://example.com/path#section") should equal(expected)
+  }
+
+  test("Uppercase and lowercase percent encoding") {
+    UriDecoder.decode("test%2Fvalue") should equal("test/value")
+    UriDecoder.decode("test%2fvalue") should equal("test/value")
+  }
+
+  test("Encoded slashes and colons in path") {
+    val expected = "https://example.com/path/with:colon"
+    UriDecoder.decode("https://example.com/path/with%3Acolon") should equal(expected)
+  }
+
+  test("Query string with encoded ampersands") {
+    val expected = "https://example.com?q=a&b"
+    UriDecoder.decode("https://example.com?q=a%26b") should equal(expected)
+  }
+
+  test("Encoded equals signs in query values") {
+    val expected = "https://example.com?key=value=another"
+    UriDecoder.decode("https://example.com?key=value%3Danother") should equal(expected)
+  }
+
+  test("URI with port number") {
+    val expected = "https://example.com:8080/path?query=value"
+    UriDecoder.decode("https://example.com:8080/path?query=value") should equal(expected)
+  }
+
+  test("Double encoding is decoded only once") {
+    // %2520 is double-encoded space (%20 -> %2520)
+    // Should decode to %20, not to a space
+    UriDecoder.decode("test%2520value") should equal("test%20value")
+  }
+
+  test("Null bytes and control characters") {
+    UriDecoder.decode("test%00value") should equal("test\u0000value")
+    UriDecoder.decode("test%0Avalue") should equal("test\nvalue")
+  }
+
+  test("URI with authentication") {
+    val expected = "https://user:pass@example.com/path"
+    UriDecoder.decode("https://user:pass@example.com/path") should equal(expected)
+  }
+
+  test("Very long URI") {
+    val path = "a" * 1000
+    val uri  = s"https://example.com/$path"
+    UriDecoder.decode(uri) should equal(uri)
+  }
+
+  import org.scalatra.util.UrlCodingUtils
+
+  test("containsInvalidUriChars detects invalid characters") {
+    // Direct tests of the detection logic
+    UrlCodingUtils.containsInvalidUriChars("hello world") should be(true)  // space is invalid
+    UrlCodingUtils.containsInvalidUriChars("hello<world") should be(true)  // < is invalid
+    UrlCodingUtils.containsInvalidUriChars("hello{world") should be(true)  // { is invalid
+    UrlCodingUtils.containsInvalidUriChars("hello|world") should be(true)  // | is invalid
+    UrlCodingUtils.containsInvalidUriChars("hello\\world") should be(true) // \ is invalid
+    UrlCodingUtils.containsInvalidUriChars("hello\"world") should be(true) // " is invalid
+  }
+
+  test("containsInvalidUriChars accepts valid URI characters") {
+    UrlCodingUtils.containsInvalidUriChars("https://example.com/path?query=value") should be(false)
+    UrlCodingUtils.containsInvalidUriChars("hello-world_test.txt") should be(false)
+    UrlCodingUtils.containsInvalidUriChars("ABCabc123") should be(false)
+    UrlCodingUtils.containsInvalidUriChars("user@example.com") should be(false)
+    UrlCodingUtils.containsInvalidUriChars("test!$&'()*+,;=") should be(false)
+  }
+
+  test("needsUrlEncoding detects unencoded invalid characters") {
+    UrlCodingUtils.needsUrlEncoding("hello world") should be(true)
+    UrlCodingUtils.needsUrlEncoding("hello<world") should be(true)
+  }
+
+  test("needsUrlEncoding returns false for already encoded strings") {
+    UrlCodingUtils.needsUrlEncoding("hello%20world") should be(false)
+    UrlCodingUtils.needsUrlEncoding("test%3Cvalue") should be(false)
+  }
+
+  test("needsUrlEncoding returns false for valid unencoded URIs") {
+    UrlCodingUtils.needsUrlEncoding("https://example.com/path") should be(false)
+  }
+
+  test("ensureUrlEncoding encodes unencoded invalid characters") {
+    UrlCodingUtils.ensureUrlEncoding("hello world") should equal("hello%20world")
+    UrlCodingUtils.ensureUrlEncoding("test<value") should include("%3C")
+  }
+
+  test("ensureUrlEncoding leaves already encoded strings unchanged") {
+    val encoded = "hello%20world"
+    UrlCodingUtils.ensureUrlEncoding(encoded) should equal(encoded)
+  }
+
+  test("ensureUrlEncoding leaves valid unencoded URIs unchanged") {
+    val uri = "https://example.com/path"
+    UrlCodingUtils.ensureUrlEncoding(uri) should equal(uri)
+  }
+}

--- a/core/src/test/scala/org/scalatra/UriDecoderTest.scala
+++ b/core/src/test/scala/org/scalatra/UriDecoderTest.scala
@@ -1,111 +1,9 @@
 package org.scalatra
 
 import org.scalatra.test.scalatest.ScalatraFunSuite
+import org.scalatest.Inspectors
 
 class UriDecoderTest extends ScalatraFunSuite {
-
-  test("Non-encoded values can be decoded") {
-    val expected = "https://example.com/foo/bar?test=80&test ab~~"
-    UriDecoder.decode(expected) should equal(expected)
-  }
-
-  test("Encoded values can be decoded") {
-    val expected = "https://example.com/foo/bar?test=80&foo=test ab"
-    UriDecoder.decode("https%3A%2F%2Fexample.com%2Ffoo%2Fbar%3Ftest%3D80%26foo%3Dtest%20ab") should equal(expected)
-  }
-
-  test("Already decoded values remain unchanged") {
-    val uri = "https://example.com/path/to/resource"
-    UriDecoder.decode(uri) should equal(uri)
-  }
-
-  test("Partially encoded URIs are decoded") {
-    val expected = "https://example.com/foo bar/baz"
-    UriDecoder.decode("https://example.com/foo%20bar/baz") should equal(expected)
-  }
-
-  test("Special characters are decoded correctly") {
-    UriDecoder.decode("test%21%40%23%24%25") should equal("test!@#$%")
-  }
-
-  test("Plus signs are NOT treated as spaces (plusIsSpace = false)") {
-    UriDecoder.decode("test+value") should equal("test+value")
-    UriDecoder.decode("test%2Bvalue") should equal("test+value")
-  }
-
-  test("Unicode characters are decoded correctly") {
-    val expected = "https://example.com/こんにちは"
-    UriDecoder.decode("https://example.com/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF") should equal(expected)
-  }
-
-  test("Emoji are decoded correctly") {
-    val expected = "test 😀 emoji"
-    UriDecoder.decode("test%20%F0%9F%98%80%20emoji") should equal(expected)
-  }
-
-  test("Mixed encoded and non-encoded characters") {
-    val expected = "https://example.com/path?query=value with spaces&other=test"
-    UriDecoder.decode("https://example.com/path?query=value%20with%20spaces&other=test") should equal(expected)
-  }
-
-  test("Reserved characters in URI components") {
-    val expected = "https://example.com/path?key=value&another=test"
-    UriDecoder.decode("https://example.com/path?key=value&another=test") should equal(expected)
-  }
-
-  test("Handles malformed percent encoding gracefully") {
-    // Single % at end
-    UriDecoder.decode("test%") should equal("test%")
-
-    // Invalid hex characters
-    UriDecoder.decode("test%ZZ") should equal("test%ZZ")
-
-    // Incomplete encoding
-    UriDecoder.decode("test%2") should equal("test%2")
-  }
-
-  test("Empty string") {
-    UriDecoder.decode("") should equal("")
-  }
-
-  test("Only percent sign") {
-    UriDecoder.decode("%") should equal("%")
-  }
-
-  test("Multiple consecutive spaces encoded") {
-    val expected = "test    multiple"
-    UriDecoder.decode("test%20%20%20%20multiple") should equal(expected)
-  }
-
-  test("Fragment identifiers are preserved") {
-    val expected = "https://example.com/path#section"
-    UriDecoder.decode("https://example.com/path#section") should equal(expected)
-  }
-
-  test("Uppercase and lowercase percent encoding") {
-    UriDecoder.decode("test%2Fvalue") should equal("test/value")
-    UriDecoder.decode("test%2fvalue") should equal("test/value")
-  }
-
-  test("Encoded slashes and colons in path") {
-    val expected = "https://example.com/path/with:colon"
-    UriDecoder.decode("https://example.com/path/with%3Acolon") should equal(expected)
-  }
-
-  test("Query string with encoded ampersands") {
-    val expected = "https://example.com?q=a&b"
-    UriDecoder.decode("https://example.com?q=a%26b") should equal(expected)
-  }
-
-  test("Encoded equals signs in query values") {
-    val expected = "https://example.com?key=value=another"
-    UriDecoder.decode("https://example.com?key=value%3Danother") should equal(expected)
-  }
-
-  test("URI with port number") {
-    val expected = "https://example.com:8080/path?query=value"
-    UriDecoder.decode("https://example.com:8080/path?query=value") should equal(expected)
-  }
 
   test("Double encoding is decoded only once") {
     // %2520 is double-encoded space (%20 -> %2520)
@@ -113,68 +11,67 @@ class UriDecoderTest extends ScalatraFunSuite {
     UriDecoder.decode("test%2520value") should equal("test%20value")
   }
 
-  test("Null bytes and control characters") {
-    UriDecoder.decode("test%00value") should equal("test\u0000value")
-    UriDecoder.decode("test%0Avalue") should equal("test\nvalue")
+  test("Non-encoded values can be decoded") {
+    val expected = "https://example.com/foo/bar?test=80&test ab~~"
+    UriDecoder.decode(expected) should equal(expected)
   }
 
-  test("URI with authentication") {
-    val expected = "https://user:pass@example.com/path"
-    UriDecoder.decode("https://user:pass@example.com/path") should equal(expected)
+  test("valid URIs pass through unchanged") {
+    Inspectors.forEvery(
+      Seq(
+        "https://example.com/path/to/resource",
+        "https://example.com/path#section",
+        "https://example.com/path?key=value&another=test",
+        "https://example.com:8080/path?query=value",
+        "https://user:pass@example.com/path",
+      )
+    ) { uri =>
+      withClue(s": $uri") {
+        UriDecoder.decode(uri) should equal(uri)
+      }
+    }
   }
 
-  test("Very long URI") {
-    val path = "a" * 1000
-    val uri  = s"https://example.com/$path"
-    UriDecoder.decode(uri) should equal(uri)
+  test("encoded characters decode correctly") {
+    Inspectors.forEvery(
+      Seq(
+        "https%3A%2F%2Fexample.com%2Ffoo"                 -> "https://example.com/foo",
+        "test%20%20%20%20multiple"                        -> "test    multiple",
+        "test%21%40%23%24%25"                             -> "test!@#$%",
+        "test%2Fvalue"                                    -> "test/value",
+        "test%2fvalue"                                    -> "test/value", // lowercase
+        "https://example.com/foo%20bar/baz"               -> "https://example.com/foo bar/baz",
+        "https://example.com/%E3%81%93%E3%82%93%E3%81%AB" -> "https://example.com/こんに",
+        "test%20%F0%9F%98%80%20emoji"                     -> "test 😀 emoji",
+        "https://example.com?q=a%26b"                     -> "https://example.com?q=a&b",
+        "https://example.com?key=value%3Danother"         -> "https://example.com?key=value=another",
+        "https://example.com/path/with%3Acolon"           -> "https://example.com/path/with:colon",
+        "https%3A%2F%2Fexample.com%2Ffoo%2Fbar%3Ftest%3D80%26foo%3Dtest%20ab" -> "https://example.com/foo/bar?test=80&foo=test ab"
+      )
+    ) { case (input, expected) =>
+      withClue(s": $input") {
+        UriDecoder.decode(input) should equal(expected)
+      }
+    }
   }
 
-  import org.scalatra.util.UrlCodingUtils
-
-  test("containsInvalidUriChars detects invalid characters") {
-    // Direct tests of the detection logic
-    UrlCodingUtils.containsInvalidUriChars("hello world") should be(true)  // space is invalid
-    UrlCodingUtils.containsInvalidUriChars("hello<world") should be(true)  // < is invalid
-    UrlCodingUtils.containsInvalidUriChars("hello{world") should be(true)  // { is invalid
-    UrlCodingUtils.containsInvalidUriChars("hello|world") should be(true)  // | is invalid
-    UrlCodingUtils.containsInvalidUriChars("hello\\world") should be(true) // \ is invalid
-    UrlCodingUtils.containsInvalidUriChars("hello\"world") should be(true) // " is invalid
-  }
-
-  test("containsInvalidUriChars accepts valid URI characters") {
-    UrlCodingUtils.containsInvalidUriChars("https://example.com/path?query=value") should be(false)
-    UrlCodingUtils.containsInvalidUriChars("hello-world_test.txt") should be(false)
-    UrlCodingUtils.containsInvalidUriChars("ABCabc123") should be(false)
-    UrlCodingUtils.containsInvalidUriChars("user@example.com") should be(false)
-    UrlCodingUtils.containsInvalidUriChars("test!$&'()*+,;=") should be(false)
-  }
-
-  test("needsUrlEncoding detects unencoded invalid characters") {
-    UrlCodingUtils.needsUrlEncoding("hello world") should be(true)
-    UrlCodingUtils.needsUrlEncoding("hello<world") should be(true)
-  }
-
-  test("needsUrlEncoding returns false for already encoded strings") {
-    UrlCodingUtils.needsUrlEncoding("hello%20world") should be(false)
-    UrlCodingUtils.needsUrlEncoding("test%3Cvalue") should be(false)
-  }
-
-  test("needsUrlEncoding returns false for valid unencoded URIs") {
-    UrlCodingUtils.needsUrlEncoding("https://example.com/path") should be(false)
-  }
-
-  test("ensureUrlEncoding encodes unencoded invalid characters") {
-    UrlCodingUtils.ensureUrlEncoding("hello world") should equal("hello%20world")
-    UrlCodingUtils.ensureUrlEncoding("test<value") should include("%3C")
-  }
-
-  test("ensureUrlEncoding leaves already encoded strings unchanged") {
-    val encoded = "hello%20world"
-    UrlCodingUtils.ensureUrlEncoding(encoded) should equal(encoded)
-  }
-
-  test("ensureUrlEncoding leaves valid unencoded URIs unchanged") {
-    val uri = "https://example.com/path"
-    UrlCodingUtils.ensureUrlEncoding(uri) should equal(uri)
+  test("Specific cases") {
+    Inspectors.forEvery(
+      Seq(
+        "test%"        -> "test%",   // single % at end
+        "test%ZZ"      -> "test%ZZ", // invalid hex
+        "test%2"       -> "test%2",  // incomplete
+        "%"            -> "%",       // only percent sign
+        ""             -> "",
+        "test+value"   -> "test+value",
+        "test%2Bvalue" -> "test+value",
+        "test%00value" -> "test\u0000value",
+        "test%0Avalue" -> "test\nvalue"
+      )
+    ) { case (input, expected) =>
+      withClue(s": $input") {
+        UriDecoder.decode(input) should equal(expected)
+      }
+    }
   }
 }

--- a/core/src/test/scala/org/scalatra/util/UrlCodingUtilsSpec.scala
+++ b/core/src/test/scala/org/scalatra/util/UrlCodingUtilsSpec.scala
@@ -1,0 +1,54 @@
+package org.scalatra.util
+
+import org.scalatra.test.scalatest.ScalatraFunSuite
+import org.scalatest.Inspectors
+
+class UrlCodingUtilsSpec extends ScalatraFunSuite {
+
+  test("containsInvalidUriChars detects invalid characters") {
+    Inspectors.forEvery(
+      Seq(
+        "hello world",
+        "hello<world",
+        "hello{world",
+        "hello|world",
+        "hello\\world",
+        "hello\"world"
+      )
+    ) { x =>
+      withClue(s": $x") {
+        UrlCodingUtils.containsInvalidUriChars(x) should be(true)
+      }
+    }
+  }
+
+  test("containsInvalidUriChars accepts valid characters") {
+    Inspectors.forEvery(
+      Seq(
+        "https://example.com/api/user",
+        "https://example.com/api/users/123/profile?sort=name&order=asc",
+        "/api/v2/resource?foo=bar&baz=1",
+        "simple",
+        ""
+      )
+    ) { x =>
+      withClue(s": $x") {
+        UrlCodingUtils.containsInvalidUriChars(x) should be(false)
+      }
+    }
+  }
+
+  test("ensureUrlEncoding encodes if needed, skips encoding if given input doesn't meet criteria") {
+    Inspectors.forEvery(
+      Seq(
+        "hello world"                   -> "hello%20world",
+        "test<value"                    -> "test%3Cvalue",
+        "hello{world"                   -> "hello%7Bworld",
+        "https://example.com/path"      -> "https://example.com/path",
+        "https://example.com/path-test" -> "https://example.com/path-test"
+      )
+    ) { case (input, expected) =>
+      UrlCodingUtils.ensureUrlEncoding(input) should equal(expected)
+    }
+  }
+}


### PR DESCRIPTION
- fixes an issue where `-` was included in the list of invalid characters
- changes the regex check to a lookup table, in a narrow benchmark small uplift of 2000-4000ns -> 100ns range, bitset solution would result in similar performance in some cases but usually losing out if the test had more varied inputs