### PR TITLE
Bump jakarta.servlet-api to 6.1.0 to align with Jakarta EE11

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     "mustmatchers",
   ).map(x => "org.scalatest" %% s"scalatest-$x" % scalatestVersion)
   lazy val servletApiJavax   = "javax.servlet"   % "javax.servlet-api"   % "4.0.1"
-  lazy val servletApiJakarta = "jakarta.servlet" % "jakarta.servlet-api" % "6.0.0"
+  lazy val servletApiJakarta = "jakarta.servlet" % "jakarta.servlet-api" % "6.1.0"
   lazy val slf4jApi          = "org.slf4j"       % "slf4j-api"           % "2.0.18"
   lazy val specs2            = Seq(
     "org.specs2" %% "specs2-core",


### PR DESCRIPTION
Ref: #1994