### PR TITLE
Fix warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -528,9 +528,9 @@ lazy val manifestSetting = packageOptions += {
 
 // Things we care about primarily because Maven Central demands them
 lazy val mavenCentralFrouFrou = Seq(
-  homepage  := Some(url("https://www.scalatra.org/")),
+  homepage  := Some(uri("https://www.scalatra.org/")),
   startYear := Some(2009),
-  licenses  := Seq(("BSD", url("https://github.com/scalatra/scalatra/raw/HEAD/LICENSE"))),
+  licenses  := Seq(("BSD", uri("https://github.com/scalatra/scalatra/raw/HEAD/LICENSE"))),
   pomExtra  := pomExtra.value ++ Group(
     <scm>
       <url>https://github.com/scalatra/scalatra</url>


### PR DESCRIPTION
```
-- Deprecation Warning: /home/runner/work/scalatra/scalatra/build.sbt:505:20 ---
505 |  homepage  := Some(url("https://www.scalatra.org/")),
    |                    ^^^
    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
-- Deprecation Warning: /home/runner/work/scalatra/scalatra/build.sbt:507:27 ---
507 |  licenses  := Seq(("BSD", url("https://github.com/scalatra/scalatra/raw/HEAD/LICENSE"))),
    |                           ^^^
    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
```