### PR TITLE
Add sbt-salad-days plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,7 @@ scalacOptions ++= Seq(
 )
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp"         % "2.3.2")
+addSbtPlugin("com.eed3si9n"   % "sbt-salad-days"  % "0.2.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc"      % "0.6.1")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.6.2")


### PR DESCRIPTION
Reducing Scaladoc JAR file size is mandatory to publish Scalatra via Central Portal as there is 80MB monthly file size limit which even one Scalatra release reaches.

Also, uploading a large bundle to Central Portal can time-out in the first place.